### PR TITLE
feat: forward OIDC access_token to LLM gateway (replaces uid-${openidId})

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -684,6 +684,13 @@ OPENID_POST_LOGOUT_REDIRECT_URI=
 # Maximum logout URL length before using logout_hint instead of id_token_hint (default: 2000)
 OPENID_MAX_LOGOUT_URL_LENGTH=
 
+# When true, all LLM requests use the user's OIDC access_token as the API key
+# (Bearer for OpenAI/custom, x-api-key for Anthropic, api-key for Azure).
+# The upstream LLM gateway is expected to validate this JWT against the IdP's
+# JWKS. Mutually exclusive with non-OIDC login providers — startup will fail
+# if both are enabled. See docs/superpowers/specs/2026-06-13-oidc-llm-forwarding-design.md
+OIDC_FORWARD_TO_LLM=false
+
 #========================#
 # SharePoint Integration #
 #========================#

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -62,6 +62,7 @@ const {
   removeNullishValues,
   DEFAULT_MEMORY_MAX_INPUT_TOKENS,
 } = require('librechat-data-provider');
+const { refreshOIDCAccessToken } = require('~/server/services/Auth/refreshOIDCToken');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
 const { encodeAndFormat } = require('~/server/services/Files/images/encode');
 const { createContextHandlers } = require('~/app/clients/prompts');
@@ -634,6 +635,7 @@ class AgentClient extends BaseClient {
             : memoryConfig.agent?.provider,
         },
         codeEnvAvailable: memoryCapabilities.has(AgentCapabilities.execute_code),
+        refreshOIDCAccessToken,
       },
       {
         getFiles: db.getFiles,
@@ -1415,6 +1417,7 @@ class AgentClient extends BaseClient {
         getUserKey: db.getUserKey,
         getUserKeyValues: db.getUserKeyValues,
       },
+      refreshOIDCAccessToken,
     });
 
     let provider = options.provider ?? titleProviderConfig.overrideProvider ?? agent.provider;

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -35,6 +35,7 @@ const {
   createOpenAIContentAggregator,
   isChatCompletionValidationFailure,
 } = require('@librechat/api');
+const { refreshOIDCAccessToken } = require('~/server/services/Auth/refreshOIDCToken');
 const {
   buildSummarizationHandlers,
   markSummarizationUsage,
@@ -337,6 +338,7 @@ const OpenAIChatCompletionController = async (req, res) => {
         skillStates,
         defaultActiveOnShare,
         manualSkills,
+        refreshOIDCAccessToken,
       },
       dbMethods,
     );
@@ -411,6 +413,7 @@ const OpenAIChatCompletionController = async (req, res) => {
           defaultActiveOnShare,
           /** @see DiscoverConnectedAgentsParams.codeEnvAvailable */
           codeEnvAvailable: enabledCapabilities.has(AgentCapabilities.execute_code),
+          refreshOIDCAccessToken,
         },
         {
           getAgent: db.getAgent,

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -43,6 +43,7 @@ const {
   createResponsesEventHandlers,
   createAggregatorEventHandlers,
 } = require('@librechat/api');
+const { refreshOIDCAccessToken } = require('~/server/services/Auth/refreshOIDCToken');
 const {
   createResponsesToolEndCallback,
   buildSummarizationHandlers,
@@ -456,6 +457,7 @@ const createResponse = async (req, res) => {
         skillStates,
         defaultActiveOnShare,
         manualSkills,
+        refreshOIDCAccessToken,
       },
       dbMethods,
     );
@@ -530,6 +532,7 @@ const createResponse = async (req, res) => {
           defaultActiveOnShare,
           /** @see DiscoverConnectedAgentsParams.codeEnvAvailable */
           codeEnvAvailable: enabledCapabilities.has(AgentCapabilities.execute_code),
+          refreshOIDCAccessToken,
         },
         {
           getAgent: db.getAgent,

--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -40,6 +40,7 @@ const {
 const { checkMigrations } = require('./services/start/migration');
 const initializeMCPs = require('./services/initializeMCPs');
 const configureSocialLogins = require('./socialLogins');
+const { assertOIDCForwardingCompatible } = require('./socialLogins');
 const createSpaFallback = require('./utils/fallback');
 const { getAppConfig } = require('./services/Config');
 const staticCache = require('./utils/staticCache');
@@ -389,6 +390,11 @@ if (cluster.isMaster) {
     if (process.env.LDAP_URL && process.env.LDAP_USER_SEARCH_BASE) {
       passport.use(ldapLogin);
     }
+
+    /* OIDC-forwarding invariant must run unconditionally — passportLogin (local)
+     * and ldapLogin above are registered without ALLOW_SOCIAL_LOGIN, so the
+     * guard inside configureSocialLogins would be bypassed otherwise. */
+    assertOIDCForwardingCompatible();
 
     if (isEnabled(ALLOW_SOCIAL_LOGIN)) {
       await configureSocialLogins(app);

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -45,6 +45,7 @@ const { checkMigrations } = require('./services/start/migration');
 const optionalJwtAuth = require('./middleware/optionalJwtAuth');
 const initializeMCPs = require('./services/initializeMCPs');
 const configureSocialLogins = require('./socialLogins');
+const { assertOIDCForwardingCompatible } = require('./socialLogins');
 const createSpaFallback = require('./utils/fallback');
 const { getAppConfig } = require('./services/Config');
 const staticCache = require('./utils/staticCache');
@@ -223,6 +224,11 @@ const startServer = async () => {
   if (process.env.LDAP_URL && process.env.LDAP_USER_SEARCH_BASE) {
     passport.use(ldapLogin);
   }
+
+  /* OIDC-forwarding invariant must run unconditionally — passportLogin (local)
+   * and ldapLogin above are registered without ALLOW_SOCIAL_LOGIN, so the
+   * guard inside configureSocialLogins would be bypassed otherwise. */
+  assertOIDCForwardingCompatible();
 
   if (isEnabled(ALLOW_SOCIAL_LOGIN)) {
     await configureSocialLogins(app);

--- a/api/server/services/Auth/refreshOIDCToken.js
+++ b/api/server/services/Auth/refreshOIDCToken.js
@@ -1,0 +1,47 @@
+const { logger } = require('@librechat/data-schemas');
+const openIdClient = require('openid-client');
+const { buildOpenIDRefreshParams } = require('@librechat/api');
+const { setOpenIDAuthTokens } = require('~/server/services/AuthService');
+const { getOpenIdConfig } = require('~/strategies/openidStrategy');
+
+/**
+ * Refreshes the user's OpenID access_token using the refresh_token stored
+ * in express-session. Updates req.session.openidTokens (via setOpenIDAuthTokens)
+ * and req.user.federatedTokens in place. Throws on any failure.
+ *
+ * @param {import('express').Request} req
+ * @returns {Promise<void>}
+ */
+async function refreshOIDCAccessToken(req) {
+  const refreshToken = req.session?.openidTokens?.refreshToken;
+  if (!refreshToken) {
+    throw new Error('No refresh_token available for OIDC refresh');
+  }
+
+  const openIdConfig = getOpenIdConfig();
+  const refreshParams = buildOpenIDRefreshParams();
+  let tokenset;
+  try {
+    tokenset = await openIdClient.refreshTokenGrant(openIdConfig, refreshToken, refreshParams);
+  } catch (error) {
+    logger.error('[refreshOIDCAccessToken] grant failed', { message: error.message });
+    throw error;
+  }
+
+  setOpenIDAuthTokens(tokenset, req, null, {
+    userId: req.user?.id,
+    existingRefreshToken: refreshToken,
+  });
+
+  if (!req.user) {
+    req.user = {};
+  }
+  req.user.federatedTokens = {
+    access_token: tokenset.access_token,
+    id_token: tokenset.id_token,
+    refresh_token: tokenset.refresh_token || refreshToken,
+    expires_at: tokenset.expires_at,
+  };
+}
+
+module.exports = { refreshOIDCAccessToken };

--- a/api/server/services/Auth/refreshOIDCToken.js
+++ b/api/server/services/Auth/refreshOIDCToken.js
@@ -1,13 +1,15 @@
 const { logger } = require('@librechat/data-schemas');
 const openIdClient = require('openid-client');
 const { buildOpenIDRefreshParams } = require('@librechat/api');
-const { setOpenIDAuthTokens } = require('~/server/services/AuthService');
-const { getOpenIdConfig } = require('~/strategies/openidStrategy');
 
 /**
  * Refreshes the user's OpenID access_token using the refresh_token stored
  * in express-session. Updates req.session.openidTokens (via setOpenIDAuthTokens)
  * and req.user.federatedTokens in place. Throws on any failure.
+ *
+ * The AuthService + openidStrategy dependencies are required lazily so server
+ * controllers that import this module do not pull in the entire app graph at
+ * module-load time (which broke jest controller tests that mock those deps).
  *
  * @param {import('express').Request} req
  * @returns {Promise<void>}
@@ -17,6 +19,9 @@ async function refreshOIDCAccessToken(req) {
   if (!refreshToken) {
     throw new Error('No refresh_token available for OIDC refresh');
   }
+
+  const { setOpenIDAuthTokens } = require('~/server/services/AuthService');
+  const { getOpenIdConfig } = require('~/strategies/openidStrategy');
 
   const openIdConfig = getOpenIdConfig();
   const refreshParams = buildOpenIDRefreshParams();

--- a/api/server/services/Auth/refreshOIDCToken.spec.js
+++ b/api/server/services/Auth/refreshOIDCToken.spec.js
@@ -1,0 +1,87 @@
+jest.mock('openid-client', () => ({ refreshTokenGrant: jest.fn() }));
+jest.mock('@librechat/api', () => ({ buildOpenIDRefreshParams: jest.fn(() => ({})) }));
+jest.mock('~/server/services/AuthService', () => ({ setOpenIDAuthTokens: jest.fn() }));
+jest.mock('~/strategies/openidStrategy', () => ({ getOpenIdConfig: jest.fn(() => 'mock-config') }));
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const openIdClient = require('openid-client');
+const { setOpenIDAuthTokens } = require('~/server/services/AuthService');
+const { refreshOIDCAccessToken } = require('./refreshOIDCToken');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('refreshOIDCAccessToken', () => {
+  it('throws when refresh_token is absent', async () => {
+    const req = { session: { openidTokens: {} }, user: { id: 'u1' } };
+    await expect(refreshOIDCAccessToken(req)).rejects.toThrow(
+      'No refresh_token available for OIDC refresh',
+    );
+    expect(openIdClient.refreshTokenGrant).not.toHaveBeenCalled();
+  });
+
+  it('on success updates session via setOpenIDAuthTokens and rewrites req.user.federatedTokens', async () => {
+    openIdClient.refreshTokenGrant.mockResolvedValue({
+      access_token: 'new-at',
+      id_token: 'new-it',
+      refresh_token: 'new-rt',
+      expires_at: 1234567890,
+    });
+    const req = {
+      session: { openidTokens: { refreshToken: 'old-rt' } },
+      user: { id: 'u1' },
+    };
+    await refreshOIDCAccessToken(req);
+    expect(openIdClient.refreshTokenGrant).toHaveBeenCalledWith('mock-config', 'old-rt', {});
+    expect(setOpenIDAuthTokens).toHaveBeenCalledWith(
+      expect.objectContaining({ access_token: 'new-at' }),
+      req,
+      null,
+      { userId: 'u1', existingRefreshToken: 'old-rt' },
+    );
+    expect(req.user.federatedTokens).toEqual({
+      access_token: 'new-at',
+      id_token: 'new-it',
+      refresh_token: 'new-rt',
+      expires_at: 1234567890,
+    });
+  });
+
+  it('preserves existing refresh_token when IdP does not return a new one (Cognito case)', async () => {
+    openIdClient.refreshTokenGrant.mockResolvedValue({
+      access_token: 'new-at',
+      id_token: 'new-it',
+      refresh_token: undefined,
+      expires_at: 1234567890,
+    });
+    const req = {
+      session: { openidTokens: { refreshToken: 'old-rt' } },
+      user: { id: 'u1' },
+    };
+    await refreshOIDCAccessToken(req);
+    expect(req.user.federatedTokens.refresh_token).toBe('old-rt');
+  });
+
+  it('propagates grant errors and logs without leaking secrets', async () => {
+    const { logger } = jest.requireMock('@librechat/data-schemas');
+    openIdClient.refreshTokenGrant.mockRejectedValue(
+      Object.assign(new Error('invalid_grant'), {
+        response: { data: { access_token: 'secret' } },
+      }),
+    );
+    const req = {
+      session: { openidTokens: { refreshToken: 'old-rt' } },
+      user: { id: 'u1' },
+    };
+    await expect(refreshOIDCAccessToken(req)).rejects.toThrow('invalid_grant');
+    expect(setOpenIDAuthTokens).not.toHaveBeenCalled();
+    for (const call of logger.error.mock.calls) {
+      for (const arg of call) {
+        expect(JSON.stringify(arg)).not.toContain('secret');
+      }
+    }
+  });
+});

--- a/api/server/services/AuthService.js
+++ b/api/server/services/AuthService.js
@@ -781,13 +781,21 @@ const setOpenIDAuthTokens = (
      * to be signed out on the next token refresh attempt.
      * The refresh token is small (opaque string) so it doesn't hit the HTTP/2 header
      * size limits that motivated session storage for the larger access_token/id_token.
+     *
+     * Cookie writes are guarded by `canWriteCookies` so this function can be invoked
+     * from non-HTTP-response code paths (e.g. the LLM-side refreshOIDCAccessToken bridge,
+     * where there is no Express response). Session writes — the source of truth — still
+     * happen unconditionally.
      */
-    res.cookie('refreshToken', refreshToken, {
-      expires: expirationDate,
-      httpOnly: true,
-      secure: shouldUseSecureCookie(),
-      sameSite: 'strict',
-    });
+    const canWriteCookies = res && typeof res.cookie === 'function';
+    if (canWriteCookies) {
+      res.cookie('refreshToken', refreshToken, {
+        expires: expirationDate,
+        httpOnly: true,
+        secure: shouldUseSecureCookie(),
+        sameSite: 'strict',
+      });
+    }
 
     /** Store tokens server-side in session to avoid large cookies */
     if (req.session) {
@@ -798,7 +806,7 @@ const setOpenIDAuthTokens = (
         expiresAt: expirationDate.getTime(),
         lastRefreshedAt: Date.now(),
       };
-    } else {
+    } else if (canWriteCookies) {
       logger.warn('[setOpenIDAuthTokens] No session available, falling back to cookies');
       res.cookie('openid_access_token', tokenset.access_token, {
         expires: expirationDate,
@@ -817,13 +825,15 @@ const setOpenIDAuthTokens = (
     }
 
     /** Small cookie to indicate token provider (required for auth middleware) */
-    res.cookie('token_provider', 'openid', {
-      expires: expirationDate,
-      httpOnly: true,
-      secure: shouldUseSecureCookie(),
-      sameSite: 'strict',
-    });
-    if (userId && isEnabled(process.env.OPENID_REUSE_TOKENS)) {
+    if (canWriteCookies) {
+      res.cookie('token_provider', 'openid', {
+        expires: expirationDate,
+        httpOnly: true,
+        secure: shouldUseSecureCookie(),
+        sameSite: 'strict',
+      });
+    }
+    if (canWriteCookies && userId && isEnabled(process.env.OPENID_REUSE_TOKENS)) {
       /** JWT-signed user ID cookie for image path validation when OPENID_REUSE_TOKENS is enabled */
       const signedUserId = jwt.sign({ id: userId }, process.env.JWT_REFRESH_SECRET, {
         expiresIn: expiryInMilliseconds / 1000,
@@ -836,7 +846,9 @@ const setOpenIDAuthTokens = (
       });
     }
 
-    setCloudFrontAuthCookies(req, res, req.user, { userId, tenantId });
+    if (canWriteCookies) {
+      setCloudFrontAuthCookies(req, res, req.user, { userId, tenantId });
+    }
 
     return appAuthToken;
   } catch (error) {

--- a/api/server/services/AuthService.spec.js
+++ b/api/server/services/AuthService.spec.js
@@ -1368,3 +1368,28 @@ describe('registerUser - allowedDomains admin-panel override', () => {
     expect(findUser).not.toHaveBeenCalled();
   });
 });
+
+describe('setOpenIDAuthTokens with null res', () => {
+  // The upcoming refreshOIDCAccessToken bridge invokes setOpenIDAuthTokens from
+  // LLM request preprocessing where no HTTP response is available. The function
+  // must tolerate res === null by writing the session (source of truth) and
+  // silently skipping every res.cookie / CloudFront cookie write.
+  it('does not throw when res is null and writes session only', () => {
+    const req = {
+      session: {},
+      user: { _id: 'u1', id: 'u1' },
+    };
+    const tokenset = {
+      access_token: 'at',
+      id_token: 'it',
+      refresh_token: 'rt',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+    };
+    expect(() => setOpenIDAuthTokens(tokenset, req, null, { userId: 'u1' })).not.toThrow();
+    expect(req.session.openidTokens).toMatchObject({
+      accessToken: 'at',
+      idToken: 'it',
+      refreshToken: 'rt',
+    });
+  });
+});

--- a/api/server/services/Endpoints/agents/addedConvo.js
+++ b/api/server/services/Endpoints/agents/addedConvo.js
@@ -8,6 +8,7 @@ const {
   loadAddedAgent: loadAddedAgentFn,
 } = require('@librechat/api');
 const { isEphemeralAgentId } = require('librechat-data-provider');
+const { refreshOIDCAccessToken } = require('~/server/services/Auth/refreshOIDCToken');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
 const { getMCPServerTools } = require('~/server/services/Config');
 const { canAuthorSkillFiles } = require('./skillDeps');
@@ -175,6 +176,7 @@ const processAddedConvo = async ({
         codeEnvAvailable,
         skillStates,
         defaultActiveOnShare,
+        refreshOIDCAccessToken,
       },
       {
         getFiles: db.getFiles,

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -29,6 +29,7 @@ const {
   getDefaultHandlers,
 } = require('~/server/controllers/agents/callbacks');
 const { loadAgentTools, loadToolsForExecution } = require('~/server/services/ToolService');
+const { refreshOIDCAccessToken } = require('~/server/services/Auth/refreshOIDCToken');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
 const {
   getSkillToolDeps,
@@ -364,6 +365,7 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
       skillStates,
       defaultActiveOnShare,
       manualSkills,
+      refreshOIDCAccessToken,
     },
     {
       getFiles: db.getFiles,
@@ -431,6 +433,7 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
       skillStates,
       defaultActiveOnShare,
       codeEnvAvailable,
+      refreshOIDCAccessToken,
     },
     {
       getAgent: db.getAgent,
@@ -642,6 +645,7 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
           codeEnvAvailable,
           skillStates,
           defaultActiveOnShare,
+          refreshOIDCAccessToken,
         },
         {
           getFiles: db.getFiles,

--- a/api/server/services/Endpoints/assistants/initalize.js
+++ b/api/server/services/Endpoints/assistants/initalize.js
@@ -1,8 +1,14 @@
 const OpenAI = require('openai');
 const { ProxyAgent } = require('undici');
-const { isUserProvided, checkUserKeyExpiry } = require('@librechat/api');
+const {
+  isUserProvided,
+  checkUserKeyExpiry,
+  ensureLLMBearer,
+  isLLMOIDCForwardingEnabled,
+} = require('@librechat/api');
 const { ErrorTypes, EModelEndpoint } = require('librechat-data-provider');
 const { getUserKeyValues, getUserKeyExpiry } = require('~/models');
+const { refreshOIDCAccessToken } = require('~/server/services/Auth/refreshOIDCToken');
 
 const initializeClient = async ({ req, res, version }) => {
   const { PROXY, OPENAI_ORGANIZATION, ASSISTANTS_API_KEY, ASSISTANTS_BASE_URL } = process.env;
@@ -39,6 +45,20 @@ const initializeClient = async ({ req, res, version }) => {
 
   if (!apiKey) {
     throw new Error('Assistants API key not provided. Please provide it again.');
+  }
+
+  // Fork-only: forward the user's OIDC access_token as the OpenAI Assistants
+  // API key. User-provided baseURL is rejected outright to prevent token
+  // exfiltration to attacker-controlled hosts (mirrors custom/initialize.ts).
+  if (isLLMOIDCForwardingEnabled() && req.user?.provider === 'openid') {
+    if (userProvidesURL) {
+      throw new Error(
+        JSON.stringify({ type: ErrorTypes.AUTH_FAILED }) +
+          ' — user-provided baseURL disallowed when forwarding OIDC bearer',
+      );
+    }
+    const { accessToken } = await ensureLLMBearer(req, { refreshOIDCAccessToken });
+    apiKey = accessToken;
   }
 
   if (baseURL) {

--- a/api/server/services/Endpoints/azureAssistants/initialize.js
+++ b/api/server/services/Endpoints/azureAssistants/initialize.js
@@ -5,9 +5,12 @@ const {
   resolveHeaders,
   constructAzureURL,
   checkUserKeyExpiry,
+  ensureLLMBearer,
+  isLLMOIDCForwardingEnabled,
 } = require('@librechat/api');
 const { ErrorTypes, EModelEndpoint, mapModelToAzureConfig } = require('librechat-data-provider');
 const { getUserKeyValues, getUserKeyExpiry } = require('~/models');
+const { refreshOIDCAccessToken } = require('~/server/services/Auth/refreshOIDCToken');
 
 class Files {
   constructor(client) {
@@ -151,6 +154,18 @@ const initializeClient = async ({ req, res, version, endpointOption, initAppClie
 
   if (!apiKey) {
     throw new Error('Assistants API key not provided. Please provide it again.');
+  }
+
+  // Fork-only: forward the user's OIDC access_token as the Azure API key.
+  // Azure assistants use the `api-key` header (resolveHeaders inserts it above
+  // for the configured-azure path); when the flag is on we replace both the
+  // SDK constructor apiKey and any pre-built `api-key` header value.
+  if (isLLMOIDCForwardingEnabled() && req.user?.provider === 'openid') {
+    const { accessToken } = await ensureLLMBearer(req, { refreshOIDCAccessToken });
+    apiKey = accessToken;
+    if (opts.defaultHeaders && opts.defaultHeaders['api-key']) {
+      opts.defaultHeaders = { ...opts.defaultHeaders, 'api-key': accessToken };
+    }
   }
 
   if (baseURL) {

--- a/api/server/socialLogins.js
+++ b/api/server/socialLogins.js
@@ -72,6 +72,70 @@ async function configureOpenId(app) {
 }
 
 /**
+ * Defense-in-depth invariant: forwarding the user's OIDC access_token to the
+ * LLM gateway requires every authenticated user to actually possess one. Any
+ * login strategy that produces a session without populating federatedTokens
+ * would let those users reach the LLM call path and fail at ensureLLMBearer
+ * with AUTH_FAILED — a confusing 500-equivalent rather than a clean
+ * configuration error at boot.
+ *
+ * Exported so callers can invoke it unconditionally — configureSocialLogins
+ * itself is only called when ALLOW_SOCIAL_LOGIN=true, but local passport
+ * (`passportLogin`) is registered unconditionally at index.js:220, so the
+ * invariant must be checked regardless of ALLOW_SOCIAL_LOGIN's value.
+ *
+ * We mirror the EXACT env conditions each provider in this file (and
+ * elsewhere) uses to register its strategy — NOT the ALLOW_*_LOGIN flags
+ * which only control button visibility in routes/config.js. And we mirror
+ * routes/config.js's default-on semantics for ALLOW_EMAIL_LOGIN.
+ *
+ * Idempotent and cheap: safe to call multiple times at boot.
+ */
+const assertOIDCForwardingCompatible = () => {
+  if (!isEnabled(process.env.OIDC_FORWARD_TO_LLM)) {
+    return;
+  }
+  const enabledNonOIDC = [];
+  if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+    enabledNonOIDC.push('google');
+  }
+  if (process.env.FACEBOOK_CLIENT_ID && process.env.FACEBOOK_CLIENT_SECRET) {
+    enabledNonOIDC.push('facebook');
+  }
+  if (process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET) {
+    enabledNonOIDC.push('github');
+  }
+  if (process.env.DISCORD_CLIENT_ID && process.env.DISCORD_CLIENT_SECRET) {
+    enabledNonOIDC.push('discord');
+  }
+  if (process.env.APPLE_CLIENT_ID && process.env.APPLE_PRIVATE_KEY_PATH) {
+    enabledNonOIDC.push('apple');
+  }
+  if (
+    process.env.SAML_ENTRY_POINT &&
+    process.env.SAML_ISSUER &&
+    process.env.SAML_CERT &&
+    process.env.SAML_SESSION_SECRET
+  ) {
+    enabledNonOIDC.push('saml');
+  }
+  if (process.env.LDAP_URL && process.env.LDAP_USER_SEARCH_BASE) {
+    enabledNonOIDC.push('ldap');
+  }
+  const emailLoginEnabled =
+    process.env.ALLOW_EMAIL_LOGIN === undefined || isEnabled(process.env.ALLOW_EMAIL_LOGIN);
+  if (emailLoginEnabled) {
+    enabledNonOIDC.push('local');
+  }
+  if (enabledNonOIDC.length > 0) {
+    throw new Error(
+      `OIDC_FORWARD_TO_LLM is enabled but non-OIDC providers are also enabled: ${enabledNonOIDC.join(', ')}. ` +
+        'Disable them or unset OIDC_FORWARD_TO_LLM.',
+    );
+  }
+};
+
+/**
  *
  * @param {Express.Application} app
  */
@@ -132,59 +196,11 @@ const configureSocialLogins = async (app) => {
     logger.info('SAML Connect configured.');
   }
 
-  if (isEnabled(process.env.OIDC_FORWARD_TO_LLM)) {
-    /**
-     * Defense-in-depth invariant: forwarding the user's OIDC access_token to
-     * the LLM gateway requires every authenticated user to actually possess
-     * one. Any login strategy that produces a session without populating
-     * federatedTokens would let those users reach the LLM call path and fail
-     * at ensureLLMBearer with AUTH_FAILED — a confusing 500-equivalent rather
-     * than a clean configuration error at boot.
-     *
-     * We mirror the EXACT env conditions each provider in this file (and
-     * elsewhere) uses to register its strategy — NOT the ALLOW_*_LOGIN flags
-     * which only control button visibility in routes/config.js. And we mirror
-     * routes/config.js's default-on semantics for ALLOW_EMAIL_LOGIN.
-     */
-    const enabledNonOIDC = [];
-    if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
-      enabledNonOIDC.push('google');
-    }
-    if (process.env.FACEBOOK_CLIENT_ID && process.env.FACEBOOK_CLIENT_SECRET) {
-      enabledNonOIDC.push('facebook');
-    }
-    if (process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET) {
-      enabledNonOIDC.push('github');
-    }
-    if (process.env.DISCORD_CLIENT_ID && process.env.DISCORD_CLIENT_SECRET) {
-      enabledNonOIDC.push('discord');
-    }
-    if (process.env.APPLE_CLIENT_ID && process.env.APPLE_PRIVATE_KEY_PATH) {
-      enabledNonOIDC.push('apple');
-    }
-    if (
-      process.env.SAML_ENTRY_POINT &&
-      process.env.SAML_ISSUER &&
-      process.env.SAML_CERT &&
-      process.env.SAML_SESSION_SECRET
-    ) {
-      enabledNonOIDC.push('saml');
-    }
-    if (process.env.LDAP_URL && process.env.LDAP_USER_SEARCH_BASE) {
-      enabledNonOIDC.push('ldap');
-    }
-    const emailLoginEnabled =
-      process.env.ALLOW_EMAIL_LOGIN === undefined || isEnabled(process.env.ALLOW_EMAIL_LOGIN);
-    if (emailLoginEnabled) {
-      enabledNonOIDC.push('local');
-    }
-    if (enabledNonOIDC.length > 0) {
-      throw new Error(
-        `OIDC_FORWARD_TO_LLM is enabled but non-OIDC providers are also enabled: ${enabledNonOIDC.join(', ')}. ` +
-          'Disable them or unset OIDC_FORWARD_TO_LLM.',
-      );
-    }
-  }
+  // Defense-in-depth guard — also called unconditionally from index.js /
+  // experimental.js at boot so it runs even when ALLOW_SOCIAL_LOGIN=false.
+  // Idempotent; cheap to call twice.
+  assertOIDCForwardingCompatible();
 };
 
 module.exports = configureSocialLogins;
+module.exports.assertOIDCForwardingCompatible = assertOIDCForwardingCompatible;

--- a/api/server/socialLogins.js
+++ b/api/server/socialLogins.js
@@ -131,6 +131,60 @@ const configureSocialLogins = async (app) => {
 
     logger.info('SAML Connect configured.');
   }
+
+  if (isEnabled(process.env.OIDC_FORWARD_TO_LLM)) {
+    /**
+     * Defense-in-depth invariant: forwarding the user's OIDC access_token to
+     * the LLM gateway requires every authenticated user to actually possess
+     * one. Any login strategy that produces a session without populating
+     * federatedTokens would let those users reach the LLM call path and fail
+     * at ensureLLMBearer with AUTH_FAILED — a confusing 500-equivalent rather
+     * than a clean configuration error at boot.
+     *
+     * We mirror the EXACT env conditions each provider in this file (and
+     * elsewhere) uses to register its strategy — NOT the ALLOW_*_LOGIN flags
+     * which only control button visibility in routes/config.js. And we mirror
+     * routes/config.js's default-on semantics for ALLOW_EMAIL_LOGIN.
+     */
+    const enabledNonOIDC = [];
+    if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+      enabledNonOIDC.push('google');
+    }
+    if (process.env.FACEBOOK_CLIENT_ID && process.env.FACEBOOK_CLIENT_SECRET) {
+      enabledNonOIDC.push('facebook');
+    }
+    if (process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET) {
+      enabledNonOIDC.push('github');
+    }
+    if (process.env.DISCORD_CLIENT_ID && process.env.DISCORD_CLIENT_SECRET) {
+      enabledNonOIDC.push('discord');
+    }
+    if (process.env.APPLE_CLIENT_ID && process.env.APPLE_PRIVATE_KEY_PATH) {
+      enabledNonOIDC.push('apple');
+    }
+    if (
+      process.env.SAML_ENTRY_POINT &&
+      process.env.SAML_ISSUER &&
+      process.env.SAML_CERT &&
+      process.env.SAML_SESSION_SECRET
+    ) {
+      enabledNonOIDC.push('saml');
+    }
+    if (process.env.LDAP_URL && process.env.LDAP_USER_SEARCH_BASE) {
+      enabledNonOIDC.push('ldap');
+    }
+    const emailLoginEnabled =
+      process.env.ALLOW_EMAIL_LOGIN === undefined || isEnabled(process.env.ALLOW_EMAIL_LOGIN);
+    if (emailLoginEnabled) {
+      enabledNonOIDC.push('local');
+    }
+    if (enabledNonOIDC.length > 0) {
+      throw new Error(
+        `OIDC_FORWARD_TO_LLM is enabled but non-OIDC providers are also enabled: ${enabledNonOIDC.join(', ')}. ` +
+          'Disable them or unset OIDC_FORWARD_TO_LLM.',
+      );
+    }
+  }
 };
 
 module.exports = configureSocialLogins;

--- a/api/server/socialLogins.spec.js
+++ b/api/server/socialLogins.spec.js
@@ -236,3 +236,62 @@ describe('configureSocialLogins — OIDC_FORWARD_TO_LLM guard', () => {
     await expect(configureSocialLogins(app)).rejects.toThrow(/OIDC_FORWARD_TO_LLM.*google/i);
   });
 });
+
+/**
+ * Regression: the C6 guard was placed inside configureSocialLogins, which
+ * api/server/index.js only invokes when ALLOW_SOCIAL_LOGIN=true. The
+ * unconditionally-registered local passportLogin meant pre-existing
+ * provider:'local' users could still log in and hit ensureLLMBearer with an
+ * opaque AUTH_FAILED. C7 extracts the guard so it can be called independently.
+ */
+describe('assertOIDCForwardingCompatible (called independently of configureSocialLogins)', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {};
+    mockIsEnabled.mockImplementation((value) => value === 'true');
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('throws when OIDC_FORWARD_TO_LLM=true and email login defaults on, regardless of ALLOW_SOCIAL_LOGIN', () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    delete process.env.ALLOW_SOCIAL_LOGIN;
+    delete process.env.ALLOW_EMAIL_LOGIN;
+    delete process.env.GOOGLE_CLIENT_ID;
+    delete process.env.GOOGLE_CLIENT_SECRET;
+    delete process.env.GITHUB_CLIENT_ID;
+    delete process.env.GITHUB_CLIENT_SECRET;
+    delete process.env.FACEBOOK_CLIENT_ID;
+    delete process.env.FACEBOOK_CLIENT_SECRET;
+    delete process.env.DISCORD_CLIENT_ID;
+    delete process.env.DISCORD_CLIENT_SECRET;
+    delete process.env.APPLE_CLIENT_ID;
+    delete process.env.APPLE_PRIVATE_KEY_PATH;
+    delete process.env.SAML_ENTRY_POINT;
+    delete process.env.LDAP_URL;
+    const { assertOIDCForwardingCompatible } = require('./socialLogins');
+    expect(() => assertOIDCForwardingCompatible()).toThrow(/OIDC_FORWARD_TO_LLM.*local/i);
+  });
+
+  it('throws when OIDC_FORWARD_TO_LLM=true and ALLOW_SOCIAL_LOGIN=false but GOOGLE_CLIENT_ID set', () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    process.env.ALLOW_SOCIAL_LOGIN = 'false';
+    process.env.ALLOW_EMAIL_LOGIN = 'false';
+    process.env.GOOGLE_CLIENT_ID = 'x';
+    process.env.GOOGLE_CLIENT_SECRET = 'x';
+    const { assertOIDCForwardingCompatible } = require('./socialLogins');
+    expect(() => assertOIDCForwardingCompatible()).toThrow(/OIDC_FORWARD_TO_LLM.*google/i);
+  });
+
+  it('is a no-op when OIDC_FORWARD_TO_LLM is unset', () => {
+    delete process.env.OIDC_FORWARD_TO_LLM;
+    process.env.GOOGLE_CLIENT_ID = 'x';
+    process.env.GOOGLE_CLIENT_SECRET = 'x';
+    const { assertOIDCForwardingCompatible } = require('./socialLogins');
+    expect(() => assertOIDCForwardingCompatible()).not.toThrow();
+  });
+});

--- a/api/server/socialLogins.spec.js
+++ b/api/server/socialLogins.spec.js
@@ -141,3 +141,98 @@ describe('configureSocialLogins OpenID session expiry', () => {
     expect(mockPassportUse).not.toHaveBeenCalled();
   });
 });
+
+describe('configureSocialLogins — OIDC_FORWARD_TO_LLM guard', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {};
+    mockSetupOpenId.mockResolvedValue({ issuer: 'https://issuer.example.com' });
+    mockIsEnabled.mockImplementation((value) => value === 'true');
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('throws when OIDC_FORWARD_TO_LLM=true and GOOGLE_CLIENT_ID + GOOGLE_CLIENT_SECRET are set', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    process.env.GOOGLE_CLIENT_ID = 'x';
+    process.env.GOOGLE_CLIENT_SECRET = 'x';
+    process.env.ALLOW_EMAIL_LOGIN = 'false';
+    const app = { use: jest.fn() };
+    await expect(configureSocialLogins(app)).rejects.toThrow(/OIDC_FORWARD_TO_LLM.*google/i);
+  });
+
+  it('succeeds when only OIDC is enabled', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    delete process.env.GOOGLE_CLIENT_ID;
+    delete process.env.GOOGLE_CLIENT_SECRET;
+    delete process.env.GITHUB_CLIENT_ID;
+    delete process.env.GITHUB_CLIENT_SECRET;
+    delete process.env.FACEBOOK_CLIENT_ID;
+    delete process.env.FACEBOOK_CLIENT_SECRET;
+    delete process.env.DISCORD_CLIENT_ID;
+    delete process.env.DISCORD_CLIENT_SECRET;
+    delete process.env.APPLE_CLIENT_ID;
+    delete process.env.APPLE_PRIVATE_KEY_PATH;
+    delete process.env.SAML_ENTRY_POINT;
+    delete process.env.SAML_ISSUER;
+    delete process.env.SAML_CERT;
+    delete process.env.SAML_SESSION_SECRET;
+    delete process.env.LDAP_URL;
+    delete process.env.LDAP_USER_SEARCH_BASE;
+    process.env.ALLOW_EMAIL_LOGIN = 'false';
+    process.env.OPENID_CLIENT_ID = 'x';
+    process.env.OPENID_CLIENT_SECRET = 'x';
+    process.env.OPENID_ISSUER = 'https://issuer.example.com';
+    process.env.OPENID_SCOPE = 'openid profile email';
+    process.env.OPENID_SESSION_SECRET = 'openid-session-secret';
+    const app = { use: jest.fn() };
+    await expect(configureSocialLogins(app)).resolves.not.toThrow();
+  });
+
+  it('does not validate when flag off', async () => {
+    delete process.env.OIDC_FORWARD_TO_LLM;
+    process.env.GOOGLE_CLIENT_ID = 'x';
+    process.env.GOOGLE_CLIENT_SECRET = 'x';
+    const app = { use: jest.fn() };
+    await expect(configureSocialLogins(app)).resolves.not.toThrow();
+  });
+
+  it('throws when OIDC_FORWARD_TO_LLM=true and ALLOW_EMAIL_LOGIN is unset (default-on)', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    delete process.env.ALLOW_EMAIL_LOGIN;
+    // ensure all other providers are off
+    delete process.env.GOOGLE_CLIENT_ID;
+    delete process.env.GOOGLE_CLIENT_SECRET;
+    delete process.env.GITHUB_CLIENT_ID;
+    delete process.env.GITHUB_CLIENT_SECRET;
+    delete process.env.FACEBOOK_CLIENT_ID;
+    delete process.env.FACEBOOK_CLIENT_SECRET;
+    delete process.env.DISCORD_CLIENT_ID;
+    delete process.env.DISCORD_CLIENT_SECRET;
+    delete process.env.APPLE_CLIENT_ID;
+    delete process.env.APPLE_PRIVATE_KEY_PATH;
+    delete process.env.SAML_ENTRY_POINT;
+    delete process.env.LDAP_URL;
+    process.env.OPENID_CLIENT_ID = 'x';
+    process.env.OPENID_CLIENT_SECRET = 'x';
+    process.env.OPENID_ISSUER = 'https://issuer.example.com';
+    process.env.OPENID_SCOPE = 'openid profile email';
+    process.env.OPENID_SESSION_SECRET = 'openid-session-secret';
+    const app = { use: jest.fn() };
+    await expect(configureSocialLogins(app)).rejects.toThrow(/OIDC_FORWARD_TO_LLM.*local/i);
+  });
+
+  it('throws when OIDC_FORWARD_TO_LLM=true and ALLOW_GOOGLE_LOGIN is unset but GOOGLE_CLIENT_ID is set', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    delete process.env.ALLOW_GOOGLE_LOGIN;
+    process.env.GOOGLE_CLIENT_ID = 'x';
+    process.env.GOOGLE_CLIENT_SECRET = 'x';
+    process.env.ALLOW_EMAIL_LOGIN = 'false'; // suppress default-on
+    const app = { use: jest.fn() };
+    await expect(configureSocialLogins(app)).rejects.toThrow(/OIDC_FORWARD_TO_LLM.*google/i);
+  });
+});

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -5,7 +5,7 @@ const client = require('openid-client');
 const jwtDecode = require('jsonwebtoken/decode');
 const { hashToken, logger, tenantStorage } = require('@librechat/data-schemas');
 const { Strategy: OpenIDStrategy } = require('openid-client/passport');
-const { CacheKeys, EModelEndpoint, ErrorTypes, SystemRoles } = require('librechat-data-provider');
+const { CacheKeys, ErrorTypes, SystemRoles } = require('librechat-data-provider');
 const {
   isEnabled,
   logHeaders,
@@ -25,7 +25,7 @@ const {
 } = require('@librechat/api');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { resizeAvatar } = require('~/server/services/Files/images/avatar');
-const { findUser, createUser, updateUser, updateUserKey, findRolesByNames } = require('~/models');
+const { findUser, createUser, updateUser, findRolesByNames } = require('~/models');
 const { getAppConfig } = require('~/server/services/Config');
 const getLogStores = require('~/cache/getLogStores');
 
@@ -830,42 +830,6 @@ async function processOpenIDAuth(tokenset, existingUsersOnly = false) {
       },
     },
   );
-
-  // Fork-only: auto-import synthetic api keys so the LLM gateway can identify
-  // the user via the `uid-${openidId}` prefix. PR-2 (OIDC access token
-  // forwarding) replaces this with real OIDC bearer forwarding and deletes
-  // these blocks entirely.
-  const FAR_FUTURE = '2038-01-19T03:14:07.000Z';
-  await updateUserKey({
-    userId: user._id.toString(),
-    name: EModelEndpoint.openAI,
-    value: JSON.stringify({ apiKey: `uid-${user.openidId}`, baseURL: '' }),
-    expiresAt: FAR_FUTURE,
-  });
-  await updateUserKey({
-    userId: user._id.toString(),
-    name: EModelEndpoint.anthropic,
-    value: `uid-${user.openidId}`,
-    expiresAt: FAR_FUTURE,
-  });
-  await updateUserKey({
-    userId: user._id.toString(),
-    name: EModelEndpoint.google,
-    value: JSON.stringify({ GOOGLE_API_KEY: `uid-${user.openidId}` }),
-    expiresAt: FAR_FUTURE,
-  });
-  await updateUserKey({
-    userId: user._id.toString(),
-    name: 'Deepseek',
-    value: JSON.stringify({ apiKey: `uid-${user.openidId}`, baseURL: '' }),
-    expiresAt: FAR_FUTURE,
-  });
-  await updateUserKey({
-    userId: user._id.toString(),
-    name: 'xai',
-    value: JSON.stringify({ apiKey: `uid-${user.openidId}`, baseURL: '' }),
-    expiresAt: FAR_FUTURE,
-  });
 
   return {
     ...user,

--- a/api/strategies/openidStrategy.spec.js
+++ b/api/strategies/openidStrategy.spec.js
@@ -2,7 +2,7 @@ const undici = require('undici');
 const fetch = require('node-fetch');
 const jwtDecode = require('jsonwebtoken/decode');
 const { ErrorTypes, FileSources } = require('librechat-data-provider');
-const { findUser, createUser, updateUser, findRolesByNames } = require('~/models');
+const { findUser, createUser, updateUser, updateUserKey, findRolesByNames } = require('~/models');
 const { getOpenIdIssuer, resolveAppConfigForUser, isEnabled } = require('@librechat/api');
 const { resizeAvatar } = require('~/server/services/Files/images/avatar');
 const { getAppConfig } = require('~/server/services/Config');
@@ -1575,6 +1575,18 @@ describe('setupOpenId', () => {
     expect(user.tokenset.id_token).toBe('test_id_token');
     expect(user.federatedTokens.access_token).toBe('test_access_token');
     expect(user.federatedTokens.id_token).toBe('test_id_token');
+  });
+
+  it('does not call updateUserKey during OIDC login (legacy uid- removed)', async () => {
+    // Regression guard for PR-2 C5: the synthetic `uid-${openidId}` per-endpoint
+    // auto-import was replaced by OIDC access_token forwarding (C4). The five
+    // legacy updateUserKey blocks must stay deleted.
+    updateUserKey.mockClear();
+
+    const { user } = await validate(tokenset);
+
+    expect(user).toBeDefined();
+    expect(updateUserKey).not.toHaveBeenCalled();
   });
 
   it('should set role to "ADMIN" if OPENID_ADMIN_ROLE is set and user has that role', async () => {

--- a/docs/architecture/oidc-llm-forwarding-scope.md
+++ b/docs/architecture/oidc-llm-forwarding-scope.md
@@ -1,0 +1,56 @@
+# OIDC → LLM Forwarding — Provider Scope
+
+When `OIDC_FORWARD_TO_LLM=true`, the user's OIDC `access_token` is forwarded
+as the API key for the **chat-completion** endpoint families listed below.
+Other endpoint families fall through to env-configured credentials by design;
+see "Intentionally out of scope" below.
+
+For the full design rationale, see the PR-2 design spec on the
+`docs/oidc-llm-forwarding-design` branch:
+`docs/superpowers/specs/2026-06-13-oidc-llm-forwarding-design.md`.
+
+## In scope — forwards OIDC bearer
+
+| Endpoint family | Initializer | Notes |
+| --- | --- | --- |
+| OpenAI | `packages/api/src/endpoints/openai/initialize.ts` | Azure branch overrides `clientOptions.azure.azureOpenAIApiKey` |
+| Anthropic | `packages/api/src/endpoints/anthropic/initialize.ts` | Sets `credentials[AuthKeys.ANTHROPIC_API_KEY]` |
+| Custom (OpenAI-compat) | `packages/api/src/endpoints/custom/initialize.ts` | Rejects `userProvidesURL` to prevent token exfiltration |
+| Azure Assistants | `api/server/services/Endpoints/azureAssistants/initialize.js` | Overrides both SDK `apiKey` and the `api-key` header |
+| OpenAI Assistants | `api/server/services/Endpoints/assistants/initalize.js` | Rejects `userProvidesURL` (mirrors custom) |
+
+## Intentionally out of scope
+
+### AWS Bedrock — `api/server/services/Endpoints/bedrock/*`
+
+Bedrock authenticates with AWS Signature Version 4. The signing process binds
+the credential to the request method, path, body hash, and timestamp; an
+IdP-issued bearer token cannot be substituted for an AWS access key / secret
+key pair. Operators who need OIDC-mediated access to Bedrock must front it
+with a gateway that performs the SigV4 exchange server-side.
+
+### Google Vertex / Gemini — `api/server/services/Endpoints/google/*`
+
+Google authenticates with GCP service-account JSON keys or OAuth 2.0
+service-account flows. Like SigV4, these are credential-format-specific and
+do not accept arbitrary IdP bearer tokens. Same gateway-fronting workaround
+applies.
+
+## Why this is safe
+
+The boot guard in `api/server/socialLogins.js::assertOIDCForwardingCompatible`
+(called unconditionally from `api/server/index.js` and
+`api/server/experimental.js`) rejects any deployment that combines
+`OIDC_FORWARD_TO_LLM=true` with a non-OIDC login provider. OIDC-only
+deployments would not realistically co-configure bedrock/google endpoints,
+because their users have no AWS or GCP credentials to make the call useful.
+
+If an operator does configure bedrock/google alongside OIDC, requests to
+those endpoints continue to use the env-configured AWS / GCP credentials —
+which is the current behavior pre-PR-2 (no silent breakage, no token
+exfiltration risk).
+
+The C9 review of PR-2 (#17) flagged this as a "missing throw" concern; the
+documented decision is to **not** throw, because doing so would force a
+breaking change on operators who legitimately use OIDC for chat completion
+and bedrock for, e.g., embeddings or fallback inference.

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -487,6 +487,10 @@ endpoints:
   #     #     deploymentName: claude-3-5-haiku@20241022  # Override for this model
 
   custom:
+    # When OIDC_FORWARD_TO_LLM=true, the `apiKey:` field on each custom endpoint
+    # is IGNORED and replaced at request time with the user's OIDC access_token.
+    # `baseURL:` must NOT be `user_provided` in this mode (the API throws at
+    # request time to prevent token exfiltration to attacker-controlled hosts).
     # Groq Example
     - name: 'groq'
       apiKey: '${GROQ_API_KEY}'

--- a/packages/api/src/agents/discovery.ts
+++ b/packages/api/src/agents/discovery.ts
@@ -2,17 +2,17 @@ import { logger } from '@librechat/data-schemas';
 import { ResourceType, PermissionBits, EModelEndpoint } from 'librechat-data-provider';
 import type { Agent, GraphEdge, TModelsConfig, TEndpointOption } from 'librechat-data-provider';
 import type { Response as ServerResponse } from 'express';
-import type { ServerRequest } from '~/types';
 import type {
   InitializedAgent,
   InitializeAgentParams,
   InitializeAgentDbMethods,
 } from './initialize';
 import type { ValidateAgentModelParams } from './validation';
-import { createEdgeCollector, filterOrphanedEdges } from './edges';
-import { createSequentialChainEdges } from './chain';
+import type { ServerRequest } from '~/types';
 import { validateAgentModel as defaultValidateAgentModel } from './validation';
 import { initializeAgent as defaultInitializeAgent } from './initialize';
+import { createEdgeCollector, filterOrphanedEdges } from './edges';
+import { createSequentialChainEdges } from './chain';
 
 /**
  * Callback invoked after a sub-agent is successfully initialized.
@@ -88,6 +88,8 @@ export interface DiscoverConnectedAgentsParams {
    * code-execution tooling even though their parent had it.
    */
   codeEnvAvailable?: InitializeAgentParams['codeEnvAvailable'];
+  /** OIDC access_token forwarding bridge, propagated to each sub-agent. */
+  refreshOIDCAccessToken?: InitializeAgentParams['refreshOIDCAccessToken'];
 }
 
 export interface DiscoverConnectedAgentsDeps {
@@ -157,6 +159,7 @@ export async function discoverConnectedAgents(
     skillStates,
     defaultActiveOnShare,
     codeEnvAvailable,
+    refreshOIDCAccessToken,
   } = params;
 
   const {
@@ -260,6 +263,7 @@ export async function discoverConnectedAgents(
         skillStates,
         defaultActiveOnShare,
         codeEnvAvailable,
+        refreshOIDCAccessToken,
       },
       db,
     );

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -23,7 +23,12 @@ import type {
 import type { GenericTool, LCToolRegistry, ToolMap, LCTool } from '@librechat/agents';
 import type { Response as ServerResponse } from 'express';
 import type { IMongoFile } from '@librechat/data-schemas';
-import type { InitializeResultBase, ServerRequest, EndpointDbMethods } from '~/types';
+import type {
+  InitializeResultBase,
+  ServerRequest,
+  EndpointDbMethods,
+  BaseInitializeParams,
+} from '~/types';
 import type { LCAvailableTools, RequestScopedMCPConnectionStore } from '../mcp/types';
 import type { ResolvedManualSkill, ResolvedAlwaysApplySkill } from './skills';
 import type { TFilterFilesByAgentAccess } from './resources';
@@ -387,6 +392,12 @@ export interface InitializeAgentParams {
    * meta user messages before the LLM call.
    */
   manualSkills?: string[];
+  /**
+   * Optional bridge for OIDC access_token forwarding to the LLM gateway. When
+   * supplied (server-layer callers always do), it is forwarded into the per-
+   * endpoint initializer via `BaseInitializeParams.refreshOIDCAccessToken`.
+   */
+  refreshOIDCAccessToken?: BaseInitializeParams['refreshOIDCAccessToken'];
 }
 
 /**
@@ -549,6 +560,7 @@ export async function initializeAgent(
     parentMessageId,
     allowedProviders,
     isInitialAgent = false,
+    refreshOIDCAccessToken,
   } = params;
   const requestFileOwnerId = req.user?.id;
 
@@ -949,6 +961,7 @@ export async function initializeAgent(
     endpoint: provider,
     model_parameters: finalModelOptions,
     db,
+    refreshOIDCAccessToken,
   });
 
   const llmConfig = options.llmConfig as Record<string, unknown>;

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -7,3 +7,4 @@ export * from './password';
 export * from './invite';
 export * from './codeapi';
 export * from './openidRoleSync';
+export * from './llmBearer';

--- a/packages/api/src/auth/llmBearer.spec.ts
+++ b/packages/api/src/auth/llmBearer.spec.ts
@@ -1,0 +1,171 @@
+import { ErrorTypes } from 'librechat-data-provider';
+import { ensureLLMBearer, isLLMOIDCForwardingEnabled } from './llmBearer';
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockRefresh = jest.fn();
+const deps = { refreshOIDCAccessToken: mockRefresh };
+
+function makeReq(overrides: Partial<{ provider: string; federatedTokens: unknown }> = {}) {
+  const user = {
+    _id: 'user-1',
+    id: 'user-1',
+    provider: 'openid',
+    federatedTokens: {
+      access_token: 'jwt-good',
+      id_token: 'id-good',
+      refresh_token: 'refresh-good',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+    },
+    ...overrides,
+  };
+  return { user } as unknown as Parameters<typeof ensureLLMBearer>[0];
+}
+
+beforeEach(() => {
+  mockRefresh.mockReset();
+});
+
+describe('ensureLLMBearer', () => {
+  it('throws AUTH_FAILED for non-OIDC user', async () => {
+    const req = makeReq({ provider: 'local' });
+    await expect(ensureLLMBearer(req, deps)).rejects.toThrow(
+      JSON.stringify({ type: ErrorTypes.AUTH_FAILED }),
+    );
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it('returns access_token without refresh when expiry > leeway', async () => {
+    const req = makeReq();
+    const result = await ensureLLMBearer(req, deps);
+    expect(result).toEqual({ accessToken: 'jwt-good', refreshed: false });
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it('triggers refresh when token expires within leeway window', async () => {
+    const req = makeReq({
+      federatedTokens: {
+        access_token: 'jwt-stale',
+        id_token: 'id-stale',
+        refresh_token: 'refresh-stale',
+        expires_at: Math.floor(Date.now() / 1000) + 30, // < 60s leeway
+      },
+    });
+    mockRefresh.mockImplementation(async (r) => {
+      (
+        r.user as { federatedTokens: { access_token: string; expires_at: number } }
+      ).federatedTokens = {
+        access_token: 'jwt-fresh',
+        id_token: 'id-fresh',
+        refresh_token: 'refresh-fresh',
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      } as never;
+    });
+    const result = await ensureLLMBearer(req, deps);
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ accessToken: 'jwt-fresh', refreshed: true });
+  });
+
+  it('propagates refresh error to caller (translation to AUTH_FAILED happens at route layer)', async () => {
+    const req = makeReq({
+      federatedTokens: {
+        access_token: 'jwt-stale',
+        expires_at: Math.floor(Date.now() / 1000) + 10,
+      },
+    });
+    mockRefresh.mockRejectedValue(new Error('invalid_grant'));
+    await expect(ensureLLMBearer(req, deps)).rejects.toThrow(/invalid_grant/);
+    await expect(ensureLLMBearer(req, deps)).rejects.not.toThrow(
+      JSON.stringify({ type: ErrorTypes.AUTH_FAILED }),
+    );
+  });
+
+  it('throws AUTH_FAILED when post-refresh token is still invalid', async () => {
+    const req = makeReq({ federatedTokens: { access_token: '', expires_at: 0 } });
+    mockRefresh.mockImplementation(async (r) => {
+      (r.user as { federatedTokens: unknown }).federatedTokens = { access_token: '' };
+    });
+    await expect(ensureLLMBearer(req, deps)).rejects.toThrow(
+      JSON.stringify({ type: ErrorTypes.AUTH_FAILED }),
+    );
+  });
+
+  it('deduplicates concurrent refresh calls for the same user', async () => {
+    const req = makeReq({
+      federatedTokens: {
+        access_token: 'jwt-stale',
+        expires_at: Math.floor(Date.now() / 1000) + 10,
+      },
+    });
+    let resolveRefresh: () => void = () => {};
+    const refreshPromise = new Promise<void>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    mockRefresh.mockImplementation(async (r) => {
+      await refreshPromise;
+      (r.user as { federatedTokens: unknown }).federatedTokens = {
+        access_token: 'jwt-fresh',
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      };
+    });
+    const calls = [
+      ensureLLMBearer(req, deps),
+      ensureLLMBearer(req, deps),
+      ensureLLMBearer(req, deps),
+      ensureLLMBearer(req, deps),
+      ensureLLMBearer(req, deps),
+    ];
+    // Let microtasks settle so all 5 calls enter the dedupedRefresh path.
+    await Promise.resolve();
+    resolveRefresh();
+    const results = await Promise.all(calls);
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+    results.forEach((r) => expect(r.accessToken).toBe('jwt-fresh'));
+  });
+
+  it('does not pass access_token literal to logger', async () => {
+    const { logger } = jest.requireMock('@librechat/data-schemas');
+    const secret = 'super-secret-jwt-xyz';
+    const req = makeReq({
+      federatedTokens: { access_token: secret, expires_at: Math.floor(Date.now() / 1000) + 10 },
+    });
+    mockRefresh.mockImplementation(async () => {});
+    try {
+      await ensureLLMBearer(req, deps);
+    } catch {
+      /* expected to throw because refresh did not update token */
+    }
+    for (const method of ['debug', 'warn', 'error'] as const) {
+      for (const call of (logger[method] as jest.Mock).mock.calls) {
+        for (const arg of call) {
+          expect(JSON.stringify(arg)).not.toContain(secret);
+        }
+      }
+    }
+  });
+});
+
+describe('isLLMOIDCForwardingEnabled', () => {
+  const original = process.env.OIDC_FORWARD_TO_LLM;
+  afterEach(() => {
+    if (original === undefined) delete process.env.OIDC_FORWARD_TO_LLM;
+    else process.env.OIDC_FORWARD_TO_LLM = original;
+  });
+
+  it('returns true when env var enabled', () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    expect(isLLMOIDCForwardingEnabled()).toBe(true);
+  });
+
+  it('returns false when env var absent', () => {
+    delete process.env.OIDC_FORWARD_TO_LLM;
+    expect(isLLMOIDCForwardingEnabled()).toBe(false);
+  });
+
+  it('returns false when env var literally "false"', () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'false';
+    expect(isLLMOIDCForwardingEnabled()).toBe(false);
+  });
+});

--- a/packages/api/src/auth/llmBearer.ts
+++ b/packages/api/src/auth/llmBearer.ts
@@ -1,0 +1,80 @@
+import { logger } from '@librechat/data-schemas';
+import { ErrorTypes } from 'librechat-data-provider';
+import type { IUser } from '@librechat/data-schemas';
+import type { Request } from 'express';
+import { extractOpenIDTokenInfo, isOpenIDTokenValid } from '~/utils/oidc';
+import { isEnabled } from '~/utils';
+
+const REFRESH_LEEWAY_SECONDS = 60;
+const inflightRefresh = new Map<string, Promise<void>>();
+
+export interface LLMBearer {
+  accessToken: string;
+  refreshed: boolean;
+}
+
+export interface EnsureLLMBearerDeps {
+  refreshOIDCAccessToken: (req: Request) => Promise<void>;
+}
+
+export function isLLMOIDCForwardingEnabled(): boolean {
+  return isEnabled(process.env.OIDC_FORWARD_TO_LLM);
+}
+
+/**
+ * Returns the user's OIDC access_token for forwarding to the upstream LLM gateway,
+ * refreshing first if the token expires within REFRESH_LEEWAY_SECONDS.
+ *
+ * @throws {Error} with JSON-encoded { type: AUTH_FAILED } if user is not OIDC or
+ *   token is invalid after refresh. Refresh errors from the IdP (`invalid_grant`,
+ *   network failures, etc.) are NOT caught here — they propagate to the caller,
+ *   which is expected to translate them at the route layer.
+ *
+ * @sideEffect The injected `refreshOIDCAccessToken` mutates `req.user.federatedTokens`
+ *   and `req.session.openidTokens` in place when invoked.
+ *
+ * @concurrency Multiple concurrent calls for the same user share a single in-flight
+ *   refresh via the `inflightRefresh` map, scoped to this process.
+ */
+export async function ensureLLMBearer(req: Request, deps: EnsureLLMBearerDeps): Promise<LLMBearer> {
+  const user = req.user as IUser | undefined;
+
+  if (!user || user.provider !== 'openid') {
+    throw new Error(JSON.stringify({ type: ErrorTypes.AUTH_FAILED }));
+  }
+
+  let tokenInfo = extractOpenIDTokenInfo(user);
+  let refreshed = false;
+
+  const needsRefresh =
+    !tokenInfo?.accessToken ||
+    (tokenInfo.expiresAt != null &&
+      tokenInfo.expiresAt - Math.floor(Date.now() / 1000) < REFRESH_LEEWAY_SECONDS);
+
+  if (needsRefresh) {
+    logger.debug('[ensureLLMBearer] refreshing access_token before LLM call');
+    // Refresh errors propagate as-is; the route layer is responsible for
+    // translating IdP errors into AUTH_FAILED responses to the client.
+    await dedupedRefresh(req, deps);
+    tokenInfo = extractOpenIDTokenInfo(req.user as IUser);
+    refreshed = true;
+  }
+
+  if (!isOpenIDTokenValid(tokenInfo) || !tokenInfo?.accessToken) {
+    throw new Error(JSON.stringify({ type: ErrorTypes.AUTH_FAILED }));
+  }
+
+  return { accessToken: tokenInfo.accessToken, refreshed };
+}
+
+async function dedupedRefresh(req: Request, deps: EnsureLLMBearerDeps): Promise<void> {
+  const userId = String((req.user as IUser)._id);
+  let pending = inflightRefresh.get(userId);
+  if (!pending) {
+    pending = deps.refreshOIDCAccessToken(req).finally(() => {
+      inflightRefresh.delete(userId);
+    });
+    inflightRefresh.set(userId, pending);
+  }
+  return pending;
+}

--- a/packages/api/src/endpoints/anthropic/initialize.spec.ts
+++ b/packages/api/src/endpoints/anthropic/initialize.spec.ts
@@ -1,0 +1,140 @@
+import { AuthKeys } from 'librechat-data-provider';
+import type { BaseInitializeParams } from '~/types';
+
+const mockGetLLMConfig = jest.fn().mockReturnValue({ llmConfig: { model: 'claude-3' } });
+jest.mock('./llm', () => ({
+  getLLMConfig: (...args: unknown[]) => mockGetLLMConfig(...args),
+}));
+
+jest.mock('./vertex', () => ({
+  loadAnthropicVertexCredentials: jest.fn(async () => ({})),
+  getVertexCredentialOptions: jest.fn(() => ({})),
+}));
+
+jest.mock('~/utils', () => ({
+  checkUserKeyExpiry: jest.fn(),
+  isEnabled: (val: unknown) =>
+    typeof val === 'string' && ['true', '1', 'yes', 'on'].includes(val.toLowerCase()),
+}));
+
+import { initializeAnthropic } from './initialize';
+
+const futureExpiry = () => Math.floor(Date.now() / 1000) + 3600;
+
+describe('initializeAnthropic — OIDC apiKey override', () => {
+  const ORIGINAL = process.env.OIDC_FORWARD_TO_LLM;
+  const ORIGINAL_KEY = process.env.ANTHROPIC_API_KEY;
+  const ORIGINAL_VERTEX = process.env.ANTHROPIC_USE_VERTEX;
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.OIDC_FORWARD_TO_LLM;
+    else process.env.OIDC_FORWARD_TO_LLM = ORIGINAL;
+    if (ORIGINAL_KEY === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = ORIGINAL_KEY;
+    if (ORIGINAL_VERTEX === undefined) delete process.env.ANTHROPIC_USE_VERTEX;
+    else process.env.ANTHROPIC_USE_VERTEX = ORIGINAL_VERTEX;
+    jest.clearAllMocks();
+    mockGetLLMConfig.mockReturnValue({ llmConfig: { model: 'claude-3' } });
+  });
+
+  it('replaces ANTHROPIC_API_KEY credential with OIDC access_token when flag on', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    process.env.ANTHROPIC_API_KEY = 'env-key';
+    await initializeAnthropic({
+      req: {
+        user: {
+          _id: 'u1',
+          id: 'u1',
+          provider: 'openid',
+          federatedTokens: {
+            access_token: 'oidc-jwt',
+            id_token: 'oidc-id',
+            refresh_token: 'oidc-r',
+            expires_at: futureExpiry(),
+          },
+        },
+        body: {},
+        config: { endpoints: {} },
+      } as unknown as BaseInitializeParams['req'],
+      endpoint: 'anthropic',
+      model_parameters: {},
+      db: { getUserKey: jest.fn() } as unknown as BaseInitializeParams['db'],
+      refreshOIDCAccessToken: jest.fn(),
+    });
+    expect(mockGetLLMConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ [AuthKeys.ANTHROPIC_API_KEY]: 'oidc-jwt' }),
+      expect.any(Object),
+    );
+  });
+
+  it('falls back to env credential when flag off', async () => {
+    delete process.env.OIDC_FORWARD_TO_LLM;
+    process.env.ANTHROPIC_API_KEY = 'env-key';
+    await initializeAnthropic({
+      req: {
+        user: {
+          _id: 'u1',
+          id: 'u1',
+          provider: 'openid',
+          federatedTokens: { access_token: 'oidc-jwt', expires_at: futureExpiry() },
+        },
+        body: {},
+        config: { endpoints: {} },
+      } as unknown as BaseInitializeParams['req'],
+      endpoint: 'anthropic',
+      model_parameters: {},
+      db: { getUserKey: jest.fn() } as unknown as BaseInitializeParams['db'],
+      refreshOIDCAccessToken: jest.fn(),
+    });
+    expect(mockGetLLMConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ [AuthKeys.ANTHROPIC_API_KEY]: 'env-key' }),
+      expect.any(Object),
+    );
+  });
+
+  it('throws AUTH_FAILED when OIDC forwarding combined with Anthropic Vertex AI', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    process.env.ANTHROPIC_USE_VERTEX = 'true';
+    await expect(
+      initializeAnthropic({
+        req: {
+          user: {
+            _id: 'u1',
+            id: 'u1',
+            provider: 'openid',
+            federatedTokens: {
+              access_token: 'oidc-jwt',
+              expires_at: futureExpiry(),
+            },
+          },
+          body: {},
+          config: { endpoints: {} },
+        } as unknown as BaseInitializeParams['req'],
+        endpoint: 'anthropic',
+        model_parameters: {},
+        db: { getUserKey: jest.fn() } as unknown as BaseInitializeParams['db'],
+        refreshOIDCAccessToken: jest.fn(),
+      }),
+    ).rejects.toThrow(/Vertex AI is incompatible/);
+  });
+
+  it('falls back to env credential when flag on but user is not OIDC', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    process.env.ANTHROPIC_API_KEY = 'env-key';
+    await initializeAnthropic({
+      req: {
+        user: { _id: 'u1', id: 'u1', provider: 'local' },
+        body: {},
+        config: { endpoints: {} },
+      } as unknown as BaseInitializeParams['req'],
+      endpoint: 'anthropic',
+      model_parameters: {},
+      db: { getUserKey: jest.fn() } as unknown as BaseInitializeParams['db'],
+      refreshOIDCAccessToken: jest.fn(),
+    });
+    expect(mockGetLLMConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ [AuthKeys.ANTHROPIC_API_KEY]: 'env-key' }),
+      expect.any(Object),
+    );
+  });
+});

--- a/packages/api/src/endpoints/anthropic/initialize.ts
+++ b/packages/api/src/endpoints/anthropic/initialize.ts
@@ -1,7 +1,8 @@
-import { EModelEndpoint, AuthKeys } from 'librechat-data-provider';
+import { EModelEndpoint, AuthKeys, ErrorTypes } from 'librechat-data-provider';
 import type { BaseInitializeParams, InitializeResultBase, AnthropicConfigOptions } from '~/types';
-import { checkUserKeyExpiry, isEnabled } from '~/utils';
 import { loadAnthropicVertexCredentials, getVertexCredentialOptions } from './vertex';
+import { ensureLLMBearer, isLLMOIDCForwardingEnabled } from '~/auth/llmBearer';
+import { checkUserKeyExpiry, isEnabled } from '~/utils';
 import { getLLMConfig } from './llm';
 
 /**
@@ -17,6 +18,7 @@ export async function initializeAnthropic({
   endpoint,
   model_parameters,
   db,
+  refreshOIDCAccessToken,
 }: BaseInitializeParams): Promise<InitializeResultBase> {
   void endpoint;
   const appConfig = req.config;
@@ -79,6 +81,20 @@ export async function initializeAnthropic({
 
   const anthropicConfig = appConfig?.endpoints?.[EModelEndpoint.anthropic];
   const allConfig = appConfig?.endpoints?.all;
+
+  // Fork-only: forward the user's OIDC access_token as the Anthropic API key.
+  // SDK wire format: x-api-key header. When the flag is off or the user is not
+  // OIDC, the original credential is preserved.
+  if (isLLMOIDCForwardingEnabled() && req.user?.provider === 'openid' && refreshOIDCAccessToken) {
+    if (useVertexAI) {
+      throw new Error(
+        JSON.stringify({ type: ErrorTypes.AUTH_FAILED }) +
+          ' — Anthropic Vertex AI is incompatible with OIDC bearer forwarding',
+      );
+    }
+    const { accessToken } = await ensureLLMBearer(req, { refreshOIDCAccessToken });
+    credentials[AuthKeys.ANTHROPIC_API_KEY] = accessToken;
+  }
 
   const result = getLLMConfig(credentials, clientOptions);
 

--- a/packages/api/src/endpoints/custom/initialize.spec.ts
+++ b/packages/api/src/endpoints/custom/initialize.spec.ts
@@ -26,6 +26,8 @@ jest.mock('~/cache', () => ({
 jest.mock('~/utils', () => ({
   isUserProvided: (val: string) => val === 'user_provided',
   checkUserKeyExpiry: jest.fn(),
+  isEnabled: (val: unknown) =>
+    typeof val === 'string' && ['true', '1', 'yes', 'on'].includes(val.toLowerCase()),
 }));
 
 const mockGetCustomEndpointConfig = jest.fn();
@@ -350,5 +352,82 @@ describe('initializeCustom – token-config fetch header forwarding', () => {
         headers: undefined,
       }),
     );
+  });
+});
+
+describe('initializeCustom — OIDC apiKey override', () => {
+  const ORIGINAL = process.env.OIDC_FORWARD_TO_LLM;
+  const futureExpiry = () => Math.floor(Date.now() / 1000) + 3600;
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.OIDC_FORWARD_TO_LLM;
+    else process.env.OIDC_FORWARD_TO_LLM = ORIGINAL;
+    jest.clearAllMocks();
+  });
+
+  it('replaces apiKey with OIDC access_token when flag on', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    mockGetCustomEndpointConfig.mockReturnValue({
+      apiKey: 'env-key',
+      baseURL: 'https://gateway.example.com/v1',
+      models: {},
+    });
+    mockGetOpenAIConfig.mockReturnValue({ llmConfig: { model: 'gpt-4' }, configOptions: {} });
+    await initializeCustom({
+      req: {
+        user: {
+          _id: 'u1',
+          id: 'u1',
+          provider: 'openid',
+          federatedTokens: {
+            access_token: 'oidc-jwt',
+            id_token: 'oidc-id',
+            refresh_token: 'oidc-r',
+            expires_at: futureExpiry(),
+          },
+        },
+        body: {},
+        config: {},
+      } as unknown as BaseInitializeParams['req'],
+      endpoint: 'myproxy',
+      model_parameters: { model: 'gpt-4' },
+      db: { getUserKeyValues: jest.fn() } as unknown as BaseInitializeParams['db'],
+      refreshOIDCAccessToken: jest.fn(),
+    });
+    expect(mockGetOpenAIConfig).toHaveBeenCalledWith('oidc-jwt', expect.any(Object), 'myproxy');
+  });
+
+  it('throws when user-provided baseURL combined with OIDC mode', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    mockGetCustomEndpointConfig.mockReturnValue({
+      apiKey: 'env-key',
+      baseURL: 'user_provided',
+      models: {},
+    });
+    await expect(
+      initializeCustom({
+        req: {
+          user: {
+            _id: 'u1',
+            id: 'u1',
+            provider: 'openid',
+            federatedTokens: {
+              access_token: 'oidc-jwt',
+              expires_at: futureExpiry(),
+            },
+          },
+          body: {},
+          config: {},
+        } as unknown as BaseInitializeParams['req'],
+        endpoint: 'myproxy',
+        model_parameters: {},
+        db: {
+          getUserKeyValues: jest
+            .fn()
+            .mockResolvedValue({ baseURL: 'https://attacker.example.com/v1' }),
+        } as unknown as BaseInitializeParams['db'],
+        refreshOIDCAccessToken: jest.fn(),
+      }),
+    ).rejects.toThrow(/user-provided baseURL disallowed/);
   });
 });

--- a/packages/api/src/endpoints/custom/initialize.ts
+++ b/packages/api/src/endpoints/custom/initialize.ts
@@ -7,6 +7,7 @@ import {
 import type { TEndpoint } from 'librechat-data-provider';
 import type { AppConfig } from '@librechat/data-schemas';
 import type { BaseInitializeParams, InitializeResultBase, EndpointTokenConfig } from '~/types';
+import { ensureLLMBearer, isLLMOIDCForwardingEnabled } from '~/auth/llmBearer';
 import { isUserProvided, checkUserKeyExpiry } from '~/utils';
 import { getOpenAIConfig } from '~/endpoints/openai/config';
 import { getCustomEndpointConfig } from '~/app/config';
@@ -61,6 +62,7 @@ export async function initializeCustom({
   endpoint,
   model_parameters,
   db,
+  refreshOIDCAccessToken,
 }: BaseInitializeParams): Promise<InitializeResultBase> {
   const appConfig = req.config;
   const { key: expiresAt } = req.body;
@@ -100,7 +102,7 @@ export async function initializeCustom({
     userValues = await db.getUserKeyValues({ userId: req.user?.id ?? '', name: endpoint });
   }
 
-  const apiKey = userProvidesKey ? userValues?.apiKey : CUSTOM_API_KEY;
+  let apiKey = userProvidesKey ? userValues?.apiKey : CUSTOM_API_KEY;
   const baseURL = userProvidesURL ? userValues?.baseURL : CUSTOM_BASE_URL;
 
   if (userProvidesKey && !apiKey) {
@@ -197,6 +199,20 @@ export async function initializeCustom({
     modelOptions,
     ...clientOptions,
   };
+
+  // Fork-only: forward the user's OIDC access_token as the API key. Custom
+  // endpoints with user-provided baseURL are rejected outright to prevent
+  // token exfiltration to attacker-controlled hosts.
+  if (isLLMOIDCForwardingEnabled() && req.user?.provider === 'openid' && refreshOIDCAccessToken) {
+    if (userProvidesURL) {
+      throw new Error(
+        JSON.stringify({ type: ErrorTypes.AUTH_FAILED }) +
+          ' — user-provided baseURL disallowed when forwarding OIDC bearer',
+      );
+    }
+    const { accessToken } = await ensureLLMBearer(req, { refreshOIDCAccessToken });
+    apiKey = accessToken;
+  }
 
   const options = getOpenAIConfig(apiKey, finalClientOptions, endpoint);
   if (options != null) {

--- a/packages/api/src/endpoints/openai/initialize.spec.ts
+++ b/packages/api/src/endpoints/openai/initialize.spec.ts
@@ -19,6 +19,8 @@ jest.mock('~/utils', () => ({
   resolveHeaders: jest.fn(() => ({})),
   isUserProvided: (val: string) => val === 'user_provided',
   checkUserKeyExpiry: jest.fn(),
+  isEnabled: (val: unknown) =>
+    typeof val === 'string' && ['true', '1', 'yes', 'on'].includes(val.toLowerCase()),
 }));
 
 import { initializeOpenAI } from './initialize';
@@ -60,6 +62,101 @@ function createParams(env: Record<string, string | undefined>): BaseInitializePa
 
   return Object.assign(params, { _restore: restore });
 }
+
+describe('initializeOpenAI — OIDC apiKey override', () => {
+  const ORIGINAL = process.env.OIDC_FORWARD_TO_LLM;
+  const ORIGINAL_KEY = process.env.OPENAI_API_KEY;
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.OIDC_FORWARD_TO_LLM;
+    else process.env.OIDC_FORWARD_TO_LLM = ORIGINAL;
+    if (ORIGINAL_KEY === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = ORIGINAL_KEY;
+    jest.clearAllMocks();
+  });
+
+  const futureExpiry = () => Math.floor(Date.now() / 1000) + 3600;
+
+  it('replaces apiKey with OIDC access_token when flag on and user is OIDC', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    process.env.OPENAI_API_KEY = 'env-key';
+    mockGetOpenAIConfig.mockReturnValue({ llmConfig: {} });
+    await initializeOpenAI({
+      req: {
+        user: {
+          _id: 'u1',
+          id: 'u1',
+          provider: 'openid',
+          federatedTokens: {
+            access_token: 'oidc-jwt',
+            id_token: 'oidc-id',
+            refresh_token: 'oidc-r',
+            expires_at: futureExpiry(),
+          },
+        },
+        body: {},
+        config: { endpoints: {} },
+      } as unknown as BaseInitializeParams['req'],
+      endpoint: EModelEndpoint.openAI,
+      model_parameters: { model: 'gpt-4' },
+      db: { getUserKeyValues: jest.fn() } as unknown as BaseInitializeParams['db'],
+      refreshOIDCAccessToken: jest.fn(),
+    });
+    expect(mockGetOpenAIConfig).toHaveBeenCalledWith(
+      'oidc-jwt',
+      expect.any(Object),
+      EModelEndpoint.openAI,
+    );
+  });
+
+  it('falls back to env apiKey when flag off', async () => {
+    delete process.env.OIDC_FORWARD_TO_LLM;
+    process.env.OPENAI_API_KEY = 'env-key';
+    mockGetOpenAIConfig.mockReturnValue({ llmConfig: {} });
+    await initializeOpenAI({
+      req: {
+        user: {
+          _id: 'u1',
+          id: 'u1',
+          provider: 'openid',
+          federatedTokens: { access_token: 'oidc-jwt', expires_at: futureExpiry() },
+        },
+        body: {},
+        config: { endpoints: {} },
+      } as unknown as BaseInitializeParams['req'],
+      endpoint: EModelEndpoint.openAI,
+      model_parameters: { model: 'gpt-4' },
+      db: { getUserKeyValues: jest.fn() } as unknown as BaseInitializeParams['db'],
+      refreshOIDCAccessToken: jest.fn(),
+    });
+    expect(mockGetOpenAIConfig).toHaveBeenCalledWith(
+      'env-key',
+      expect.any(Object),
+      EModelEndpoint.openAI,
+    );
+  });
+
+  it('falls back to env apiKey when flag on but user is not OIDC', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    process.env.OPENAI_API_KEY = 'env-key';
+    mockGetOpenAIConfig.mockReturnValue({ llmConfig: {} });
+    await initializeOpenAI({
+      req: {
+        user: { _id: 'u1', id: 'u1', provider: 'local' },
+        body: {},
+        config: { endpoints: {} },
+      } as unknown as BaseInitializeParams['req'],
+      endpoint: EModelEndpoint.openAI,
+      model_parameters: { model: 'gpt-4' },
+      db: { getUserKeyValues: jest.fn() } as unknown as BaseInitializeParams['db'],
+      refreshOIDCAccessToken: jest.fn(),
+    });
+    expect(mockGetOpenAIConfig).toHaveBeenCalledWith(
+      'env-key',
+      expect.any(Object),
+      EModelEndpoint.openAI,
+    );
+  });
+});
 
 describe('initializeOpenAI – SSRF guard wiring', () => {
   afterEach(() => {

--- a/packages/api/src/endpoints/openai/initialize.ts
+++ b/packages/api/src/endpoints/openai/initialize.ts
@@ -6,6 +6,7 @@ import type {
   UserKeyValues,
 } from '~/types';
 import { getAzureCredentials, resolveHeaders, isUserProvided, checkUserKeyExpiry } from '~/utils';
+import { ensureLLMBearer, isLLMOIDCForwardingEnabled } from '~/auth/llmBearer';
 import { validateEndpointURL } from '~/auth';
 import { getOpenAIConfig } from './config';
 
@@ -22,6 +23,7 @@ export async function initializeOpenAI({
   endpoint,
   model_parameters,
   db,
+  refreshOIDCAccessToken,
 }: BaseInitializeParams): Promise<InitializeResultBase> {
   const appConfig = req.config;
   const { PROXY, OPENAI_API_KEY, AZURE_API_KEY, OPENAI_REVERSE_PROXY, AZURE_OPENAI_BASEURL } =
@@ -143,6 +145,19 @@ export async function initializeOpenAI({
       clientOptions.headers = {};
     }
     clientOptions.headers['x-cs-client-ip'] = clientIp;
+  }
+
+  // Fork-only: forward the user's OIDC access_token as the API key.
+  // SDK header semantics handle the wire format (OpenAI uses
+  // Authorization: Bearer, Azure uses api-key). When the flag is off
+  // or the user is not OIDC, the original apiKey is preserved, or when
+  // refreshOIDCAccessToken is not injected (e.g., older unit-test call paths).
+  if (isLLMOIDCForwardingEnabled() && req.user?.provider === 'openid' && refreshOIDCAccessToken) {
+    const { accessToken } = await ensureLLMBearer(req, { refreshOIDCAccessToken });
+    apiKey = accessToken;
+    if (isAzureOpenAI && clientOptions.azure) {
+      clientOptions.azure = { ...clientOptions.azure, azureOpenAIApiKey: accessToken };
+    }
   }
 
   const finalClientOptions: OpenAIConfigOptions = {

--- a/packages/api/src/types/endpoints.ts
+++ b/packages/api/src/types/endpoints.ts
@@ -1,4 +1,5 @@
 import type { ClientOptions, OpenAIClientOptions } from '@librechat/agents';
+import type { Request as ExpressRequest } from 'express';
 import type { TConfig } from 'librechat-data-provider';
 import type { EndpointTokenConfig, ServerRequest } from '~/types';
 
@@ -48,6 +49,12 @@ export interface BaseInitializeParams {
   model_parameters?: Record<string, unknown>;
   /** Database methods for user key operations */
   db: EndpointDbMethods;
+  /**
+   * Injected by api/server/ callers. Bridges to openid-client +
+   * AuthService.setOpenIDAuthTokens. Undefined in unit tests or older
+   * call paths — when undefined, the OIDC bearer override is skipped.
+   */
+  refreshOIDCAccessToken?: (req: ExpressRequest) => Promise<void>;
 }
 
 /**


### PR DESCRIPTION
**Re-opening from #17** (auto-closed when base branch \`chore/merge-upstream-v0.8.6\` was deleted after #16 merged).

Implements the design in \`docs/superpowers/specs/2026-06-13-oidc-llm-forwarding-design.md\` (merged via #18).

Replaces the legacy synthetic \`uid-${openidId}\` API key with forwarding of the user's real OIDC \`access_token\` (signed JWT) as the credential for all LLM-bound requests. The upstream LLM gateway is expected to verify the JWT against the IdP's JWKS endpoint.

## Commits (9)

| SHA | Commit | Purpose |
|---|---|---|
| 136ded98f | C1 feat(api): add ensureLLMBearer + isLLMOIDCForwardingEnabled + tests | Pure helper, 60s pre-refresh, per-user dedup |
| a5dde4a8a | C2 feat(auth): tolerate null res in setOpenIDAuthTokens | Required for non-HTTP-response call paths |
| 1f83a2230 | C3 feat(api): add refreshOIDCAccessToken bridge + tests | Server-layer bridge to openid-client.refreshTokenGrant |
| 9b73d0713 | C4 feat(endpoints): forward OIDC access_token as apiKey across all LLM endpoints | 4 initializers + DI wiring + Anthropic Vertex guard |
| 227a033b7 | C5 chore(openid): remove legacy uid-\${openidId} updateUserKey auto-import | Cleanup |
| 5ba2a8fde | C6 feat(startup): reject non-OIDC providers when OIDC_FORWARD_TO_LLM=true + docs | Startup guard (with security review fixes) |
| 5628bfb39 | C7 fix(startup): enforce OIDC_FORWARD_TO_LLM guard unconditionally at boot | Critical: guard bypassed when ALLOW_SOCIAL_LOGIN=false |
| c0c2bd35f | C8 feat(assistants): forward OIDC access_token in regular OpenAI Assistants initializer | Critical: missing endpoint |
| 64f9efc58 | C9 docs(spec): note bedrock and google fall outside OIDC forwarding scope | Doc scope clarification |

## Rollout

Flag-gated by \`OIDC_FORWARD_TO_LLM=false\` (default off). See spec §8 for the staged rollout plan.

## Deferred to staging

Packet-capture verification of \`Authorization: Bearer <jwt>\` (OpenAI), \`x-api-key: <jwt>\` (Anthropic), \`api-key: <jwt>\` (Azure) requires a real OIDC IdP + LLM gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)