### PR TITLE
fix: address review findings on OIDC LLM forwarding (PR-2 follow-up)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -689,6 +689,9 @@ OPENID_MAX_LOGOUT_URL_LENGTH=
 # The upstream LLM gateway is expected to validate this JWT against the IdP's
 # JWKS. Mutually exclusive with non-OIDC login providers — startup will fail
 # if both are enabled. See docs/superpowers/specs/2026-06-13-oidc-llm-forwarding-design.md
+# Mutually exclusive with OPENID_REUSE_TOKENS=true — that combination
+# would silently de-sync the openid_user_id cookie on every LLM-side
+# refresh; startup fails loudly if both are set.
 OIDC_FORWARD_TO_LLM=false
 
 #========================#

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1134,10 +1134,12 @@ class AgentClient extends BaseClient {
           runId: this.responseMessageId,
           signal: abortController.signal,
           customHandlers: this.options.eventHandlers,
+          req: this.options.req,
           requestBody: config.configurable.requestBody,
           user: createSafeUser(this.options.req?.user),
           summarizationConfig: appConfig?.summarization,
           appConfig,
+          refreshOIDCAccessToken,
           tokenCounter,
         });
 

--- a/api/server/services/Auth/refreshOIDCToken.js
+++ b/api/server/services/Auth/refreshOIDCToken.js
@@ -29,7 +29,15 @@ async function refreshOIDCAccessToken(req) {
   try {
     tokenset = await openIdClient.refreshTokenGrant(openIdConfig, refreshToken, refreshParams);
   } catch (error) {
-    logger.error('[refreshOIDCAccessToken] grant failed', { message: error.message });
+    logger.error('[refreshOIDCAccessToken] grant failed', {
+      name: error.name,
+      code: error.code,
+      status: error.response?.status,
+      errorCode: error.error,
+      errorDescription: error.error_description,
+      cause: error.cause,
+      message: error.message,
+    });
     throw error;
   }
 

--- a/api/server/services/Auth/refreshOIDCToken.spec.js
+++ b/api/server/services/Auth/refreshOIDCToken.spec.js
@@ -85,6 +85,41 @@ describe('refreshOIDCAccessToken', () => {
     }
   });
 
+  it('writes IdP expires_at (seconds) to req.user but cookie-expiry (ms) to session — asymmetry is intentional', async () => {
+    const idpExpiresAt = Math.floor(Date.now() / 1000) + 3600;
+    openIdClient.refreshTokenGrant.mockResolvedValue({
+      access_token: 'new-at',
+      id_token: 'new-it',
+      refresh_token: 'new-rt',
+      expires_at: idpExpiresAt,
+    });
+
+    setOpenIDAuthTokens.mockImplementation((tokenset, req) => {
+      const expiryMs = Date.now() + 15 * 60 * 1000;
+      req.session.openidTokens = {
+        accessToken: tokenset.access_token,
+        idToken: tokenset.id_token,
+        refreshToken: tokenset.refresh_token,
+        expiresAt: expiryMs,
+      };
+    });
+
+    const req = {
+      session: { openidTokens: { refreshToken: 'old-rt' } },
+      user: { id: 'u1' },
+    };
+    await refreshOIDCAccessToken(req);
+
+    expect(req.user.federatedTokens.expires_at).toBe(idpExpiresAt);
+
+    expect(req.session.openidTokens.expiresAt).not.toBe(idpExpiresAt);
+    expect(req.session.openidTokens.expiresAt).toBeGreaterThan(Date.now());
+
+    expect(typeof req.user.federatedTokens.expires_at).toBe('number');
+    expect(typeof req.session.openidTokens.expiresAt).toBe('number');
+    expect(req.user.federatedTokens.expires_at).toBeLessThan(req.session.openidTokens.expiresAt);
+  });
+
   it('logs structured error context (code, status, error_description, etc.) without leaking secrets', async () => {
     const { logger } = jest.requireMock('@librechat/data-schemas');
     const richError = Object.assign(new Error('invalid_grant'), {

--- a/api/server/services/Auth/refreshOIDCToken.spec.js
+++ b/api/server/services/Auth/refreshOIDCToken.spec.js
@@ -84,4 +84,43 @@ describe('refreshOIDCAccessToken', () => {
       }
     }
   });
+
+  it('logs structured error context (code, status, error_description, etc.) without leaking secrets', async () => {
+    const { logger } = jest.requireMock('@librechat/data-schemas');
+    const richError = Object.assign(new Error('invalid_grant'), {
+      name: 'OAuth2Error',
+      code: 'OAUTH_INVALID_GRANT',
+      error: 'invalid_grant',
+      error_description: 'Refresh token expired',
+      cause: new Error('upstream timeout'),
+      response: {
+        status: 400,
+        data: { access_token: 'secret-leaked-token' },
+      },
+    });
+    openIdClient.refreshTokenGrant.mockRejectedValue(richError);
+    const req = {
+      session: { openidTokens: { refreshToken: 'old-rt' } },
+      user: { id: 'u1' },
+    };
+    await expect(refreshOIDCAccessToken(req)).rejects.toThrow('invalid_grant');
+
+    expect(logger.error).toHaveBeenCalledWith(
+      '[refreshOIDCAccessToken] grant failed',
+      expect.objectContaining({
+        name: 'OAuth2Error',
+        code: 'OAUTH_INVALID_GRANT',
+        status: 400,
+        errorCode: 'invalid_grant',
+        errorDescription: 'Refresh token expired',
+        message: 'invalid_grant',
+      }),
+    );
+
+    for (const call of logger.error.mock.calls) {
+      for (const arg of call) {
+        expect(JSON.stringify(arg)).not.toContain('secret-leaked-token');
+      }
+    }
+  });
 });

--- a/api/server/services/Endpoints/assistants/initalize.spec.js
+++ b/api/server/services/Endpoints/assistants/initalize.spec.js
@@ -1,0 +1,118 @@
+const mockEnsureLLMBearer = jest.fn();
+const mockIsLLMOIDCForwardingEnabled = jest.fn();
+const mockIsUserProvided = jest.fn();
+
+jest.mock('@librechat/api', () => ({
+  ...jest.requireActual('@librechat/api'),
+  ensureLLMBearer: (...args) => mockEnsureLLMBearer(...args),
+  isLLMOIDCForwardingEnabled: (...args) => mockIsLLMOIDCForwardingEnabled(...args),
+  isUserProvided: (...args) => mockIsUserProvided(...args),
+  checkUserKeyExpiry: jest.fn(),
+}));
+
+jest.mock('~/models', () => ({
+  getUserKeyValues: jest.fn().mockResolvedValue({
+    apiKey: 'user-key',
+    baseURL: 'https://user-controlled.example.com/v1',
+  }),
+  getUserKeyExpiry: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('~/server/services/Auth/refreshOIDCToken', () => ({
+  refreshOIDCAccessToken: jest.fn(),
+}));
+
+const mockOpenAICtor = jest.fn();
+jest.mock('openai', () => {
+  return function MockOpenAI(opts) {
+    mockOpenAICtor(opts);
+  };
+});
+
+const initializeClient = require('./initalize');
+const { ErrorTypes } = require('librechat-data-provider');
+
+const ORIGINAL_KEY = process.env.ASSISTANTS_API_KEY;
+const ORIGINAL_URL = process.env.ASSISTANTS_BASE_URL;
+const ORIGINAL_FLAG = process.env.OIDC_FORWARD_TO_LLM;
+
+function makeReq({ provider = 'openid' } = {}) {
+  return {
+    user: { id: 'u-1', provider },
+    body: {},
+  };
+}
+
+describe('assistants initializeClient — OIDC apiKey override', () => {
+  beforeEach(() => {
+    process.env.ASSISTANTS_API_KEY = 'env-assistants-key';
+    process.env.ASSISTANTS_BASE_URL = 'https://api.openai.com/v1';
+    jest.clearAllMocks();
+    mockIsUserProvided.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_KEY === undefined) delete process.env.ASSISTANTS_API_KEY;
+    else process.env.ASSISTANTS_API_KEY = ORIGINAL_KEY;
+    if (ORIGINAL_URL === undefined) delete process.env.ASSISTANTS_BASE_URL;
+    else process.env.ASSISTANTS_BASE_URL = ORIGINAL_URL;
+    if (ORIGINAL_FLAG === undefined) delete process.env.OIDC_FORWARD_TO_LLM;
+    else process.env.OIDC_FORWARD_TO_LLM = ORIGINAL_FLAG;
+  });
+
+  it('overrides apiKey with OIDC access_token when flag on + OIDC user + admin baseURL', async () => {
+    mockIsLLMOIDCForwardingEnabled.mockReturnValue(true);
+    mockEnsureLLMBearer.mockResolvedValue({ accessToken: 'oidc-jwt' });
+
+    const result = await initializeClient({ req: makeReq(), res: {}, version: 2 });
+
+    expect(mockEnsureLLMBearer).toHaveBeenCalledTimes(1);
+    expect(result.openAIApiKey).toBe('oidc-jwt');
+    expect(mockOpenAICtor).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'oidc-jwt' }));
+  });
+
+  it('throws AUTH_FAILED when userProvidesURL + flag on + OIDC user (security guard)', async () => {
+    mockIsLLMOIDCForwardingEnabled.mockReturnValue(true);
+    mockEnsureLLMBearer.mockResolvedValue({ accessToken: 'oidc-jwt' });
+    // ASSISTANTS_BASE_URL is "user_provided"
+    mockIsUserProvided.mockImplementation((val) => val === 'user_provided');
+    process.env.ASSISTANTS_BASE_URL = 'user_provided';
+
+    await expect(initializeClient({ req: makeReq(), res: {}, version: 2 })).rejects.toThrow(
+      /user-provided baseURL disallowed/,
+    );
+    // The thrown payload also contains the AUTH_FAILED type
+    try {
+      await initializeClient({ req: makeReq(), res: {}, version: 2 });
+    } catch (err) {
+      expect(err.message).toContain(ErrorTypes.AUTH_FAILED);
+    }
+    expect(mockOpenAICtor).not.toHaveBeenCalled();
+    expect(mockEnsureLLMBearer).not.toHaveBeenCalled();
+  });
+
+  it('falls back to env apiKey when flag is off (even for OIDC user)', async () => {
+    mockIsLLMOIDCForwardingEnabled.mockReturnValue(false);
+
+    const result = await initializeClient({ req: makeReq(), res: {}, version: 2 });
+
+    expect(mockEnsureLLMBearer).not.toHaveBeenCalled();
+    expect(result.openAIApiKey).toBe('env-assistants-key');
+    expect(mockOpenAICtor).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: 'env-assistants-key' }),
+    );
+  });
+
+  it('falls back to env apiKey for non-OIDC user even when flag is on', async () => {
+    mockIsLLMOIDCForwardingEnabled.mockReturnValue(true);
+
+    const result = await initializeClient({
+      req: makeReq({ provider: 'local' }),
+      res: {},
+      version: 2,
+    });
+
+    expect(mockEnsureLLMBearer).not.toHaveBeenCalled();
+    expect(result.openAIApiKey).toBe('env-assistants-key');
+  });
+});

--- a/api/server/services/Endpoints/azureAssistants/initialize.spec.js
+++ b/api/server/services/Endpoints/azureAssistants/initialize.spec.js
@@ -1,0 +1,151 @@
+const mockEnsureLLMBearer = jest.fn();
+const mockIsLLMOIDCForwardingEnabled = jest.fn();
+
+jest.mock('@librechat/api', () => ({
+  ...jest.requireActual('@librechat/api'),
+  ensureLLMBearer: (...args) => mockEnsureLLMBearer(...args),
+  isLLMOIDCForwardingEnabled: (...args) => mockIsLLMOIDCForwardingEnabled(...args),
+  isUserProvided: jest.fn(() => false),
+  checkUserKeyExpiry: jest.fn(),
+  resolveHeaders: jest.fn(({ headers }) => ({ ...headers })),
+  constructAzureURL: jest.fn(({ baseURL }) => baseURL),
+}));
+
+jest.mock('~/models', () => ({
+  getUserKeyValues: jest.fn(),
+  getUserKeyExpiry: jest.fn(),
+}));
+
+jest.mock('~/server/services/Auth/refreshOIDCToken', () => ({
+  refreshOIDCAccessToken: jest.fn(),
+}));
+
+const mockMapModelToAzureConfig = jest.fn();
+jest.mock('librechat-data-provider', () => ({
+  ...jest.requireActual('librechat-data-provider'),
+  mapModelToAzureConfig: (...args) => mockMapModelToAzureConfig(...args),
+}));
+
+const mockOpenAICtor = jest.fn();
+jest.mock('openai', () => {
+  const Mock = function MockOpenAI(opts) {
+    mockOpenAICtor(opts);
+    this.beta = { assistants: {} };
+    this.locals = {};
+  };
+  return Mock;
+});
+
+const initializeClient = require('./initialize');
+
+const ORIGINAL_KEY = process.env.AZURE_ASSISTANTS_API_KEY;
+const ORIGINAL_FLAG = process.env.OIDC_FORWARD_TO_LLM;
+
+function makeReq({ provider = 'openid' } = {}) {
+  return {
+    user: { id: 'u-1', provider },
+    body: {},
+    query: {},
+    config: { endpoints: {} },
+  };
+}
+
+describe('azureAssistants initializeClient — OIDC apiKey override', () => {
+  beforeEach(() => {
+    process.env.AZURE_ASSISTANTS_API_KEY = 'env-azure-key';
+    delete process.env.AZURE_ASSISTANTS_BASE_URL;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_KEY === undefined) delete process.env.AZURE_ASSISTANTS_API_KEY;
+    else process.env.AZURE_ASSISTANTS_API_KEY = ORIGINAL_KEY;
+    if (ORIGINAL_FLAG === undefined) delete process.env.OIDC_FORWARD_TO_LLM;
+    else process.env.OIDC_FORWARD_TO_LLM = ORIGINAL_FLAG;
+  });
+
+  it('overrides apiKey when flag on + OIDC user (no pre-built api-key header)', async () => {
+    mockIsLLMOIDCForwardingEnabled.mockReturnValue(true);
+    mockEnsureLLMBearer.mockResolvedValue({ accessToken: 'oidc-jwt' });
+
+    const result = await initializeClient({
+      req: makeReq(),
+      res: {},
+      version: 2,
+      endpointOption: {},
+    });
+
+    expect(mockEnsureLLMBearer).toHaveBeenCalledTimes(1);
+    expect(result.openAIApiKey).toBe('oidc-jwt');
+    expect(mockOpenAICtor).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'oidc-jwt' }));
+  });
+
+  it('overrides BOTH apiKey AND opts.defaultHeaders["api-key"] when azureConfig already populated the header', async () => {
+    mockIsLLMOIDCForwardingEnabled.mockReturnValue(true);
+    mockEnsureLLMBearer.mockResolvedValue({ accessToken: 'oidc-jwt' });
+    mockMapModelToAzureConfig.mockReturnValue({
+      azureOptions: {
+        azureOpenAIApiKey: 'azure-static-key',
+        azureOpenAIApiVersion: '2024-02-15',
+        azureOpenAIApiDeploymentName: 'dep',
+      },
+      baseURL: 'https://acme.openai.azure.com/openai',
+      headers: {},
+      serverless: false,
+    });
+
+    const req = makeReq();
+    req.config = {
+      endpoints: {
+        azureOpenAI: {
+          assistants: true,
+          modelGroupMap: { 'gpt-4': { group: 'g' } },
+          groupMap: { g: {} },
+          assistantModels: ['gpt-4'],
+        },
+      },
+    };
+    req.body.model = 'gpt-4';
+
+    const result = await initializeClient({
+      req,
+      res: {},
+      version: 2,
+      endpointOption: {},
+    });
+
+    expect(result.openAIApiKey).toBe('oidc-jwt');
+    const ctorArg = mockOpenAICtor.mock.calls[0][0];
+    expect(ctorArg.apiKey).toBe('oidc-jwt');
+    expect(ctorArg.defaultHeaders['api-key']).toBe('oidc-jwt');
+    expect(ctorArg.defaultHeaders['api-key']).not.toBe('azure-static-key');
+  });
+
+  it('falls back to env apiKey when flag is off', async () => {
+    mockIsLLMOIDCForwardingEnabled.mockReturnValue(false);
+
+    const result = await initializeClient({
+      req: makeReq(),
+      res: {},
+      version: 2,
+      endpointOption: {},
+    });
+
+    expect(mockEnsureLLMBearer).not.toHaveBeenCalled();
+    expect(result.openAIApiKey).toBe('env-azure-key');
+  });
+
+  it('falls back to env apiKey for non-OIDC user even when flag is on', async () => {
+    mockIsLLMOIDCForwardingEnabled.mockReturnValue(true);
+
+    const result = await initializeClient({
+      req: makeReq({ provider: 'local' }),
+      res: {},
+      version: 2,
+      endpointOption: {},
+    });
+
+    expect(mockEnsureLLMBearer).not.toHaveBeenCalled();
+    expect(result.openAIApiKey).toBe('env-azure-key');
+  });
+});

--- a/api/server/socialLogins.js
+++ b/api/server/socialLogins.js
@@ -95,6 +95,15 @@ const assertOIDCForwardingCompatible = () => {
   if (!isEnabled(process.env.OIDC_FORWARD_TO_LLM)) {
     return;
   }
+  if (isEnabled(process.env.OPENID_REUSE_TOKENS)) {
+    throw new Error(
+      'OIDC_FORWARD_TO_LLM is enabled together with OPENID_REUSE_TOKENS. ' +
+        'This combination silently de-syncs the openid_user_id cookie because ' +
+        'every LLM-side token refresh skips cookie writes (no Express response ' +
+        'available in the bridge). Disable OPENID_REUSE_TOKENS, or unset ' +
+        'OIDC_FORWARD_TO_LLM. See docs/superpowers/specs/2026-06-13-oidc-llm-forwarding-design.md.',
+    );
+  }
   const enabledNonOIDC = [];
   if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
     enabledNonOIDC.push('google');

--- a/api/server/socialLogins.spec.js
+++ b/api/server/socialLogins.spec.js
@@ -294,4 +294,31 @@ describe('assertOIDCForwardingCompatible (called independently of configureSocia
     const { assertOIDCForwardingCompatible } = require('./socialLogins');
     expect(() => assertOIDCForwardingCompatible()).not.toThrow();
   });
+
+  it('throws when OIDC_FORWARD_TO_LLM=true and OPENID_REUSE_TOKENS=true', () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    process.env.OPENID_REUSE_TOKENS = 'true';
+    process.env.ALLOW_EMAIL_LOGIN = 'false';
+    delete process.env.GOOGLE_CLIENT_ID;
+    delete process.env.GOOGLE_CLIENT_SECRET;
+    delete process.env.GITHUB_CLIENT_ID;
+    delete process.env.GITHUB_CLIENT_SECRET;
+    delete process.env.FACEBOOK_CLIENT_ID;
+    delete process.env.FACEBOOK_CLIENT_SECRET;
+    delete process.env.DISCORD_CLIENT_ID;
+    delete process.env.DISCORD_CLIENT_SECRET;
+    delete process.env.APPLE_CLIENT_ID;
+    delete process.env.APPLE_PRIVATE_KEY_PATH;
+    delete process.env.SAML_ENTRY_POINT;
+    delete process.env.LDAP_URL;
+    const { assertOIDCForwardingCompatible } = require('./socialLogins');
+    expect(() => assertOIDCForwardingCompatible()).toThrow(/OPENID_REUSE_TOKENS/);
+  });
+
+  it('does not validate OPENID_REUSE_TOKENS when OIDC_FORWARD_TO_LLM is off', () => {
+    delete process.env.OIDC_FORWARD_TO_LLM;
+    process.env.OPENID_REUSE_TOKENS = 'true';
+    const { assertOIDCForwardingCompatible } = require('./socialLogins');
+    expect(() => assertOIDCForwardingCompatible()).not.toThrow();
+  });
 });

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -1,12 +1,12 @@
 import { logger } from '@librechat/data-schemas';
-import type { AppConfig } from '@librechat/data-schemas';
-import type { SummarizationConfig, TEndpoint } from 'librechat-data-provider';
 import {
   EModelEndpoint,
   FileSources,
   MAX_SUBAGENT_DEPTH,
   MAX_SUBAGENT_RUN_CONFIGS,
 } from 'librechat-data-provider';
+import type { SummarizationConfig, TEndpoint } from 'librechat-data-provider';
+import type { AppConfig } from '@librechat/data-schemas';
 import { createRun } from '~/agents/run';
 
 // Mock winston logger — `format` must be callable so @librechat/data-schemas
@@ -146,6 +146,8 @@ async function callAndCapture(
     summarizationConfig?: SummarizationConfig;
     initialSummary?: { text: string; tokenCount: number };
     appConfig?: AppConfig;
+    req?: unknown;
+    refreshOIDCAccessToken?: (req: unknown) => Promise<void>;
   } = {},
 ) {
   const agents = opts.agents ?? [makeAgent()];
@@ -157,6 +159,8 @@ async function callAndCapture(
     summarizationConfig: opts.summarizationConfig,
     initialSummary: opts.initialSummary,
     appConfig: opts.appConfig,
+    req: opts.req as never,
+    refreshOIDCAccessToken: opts.refreshOIDCAccessToken as never,
     streaming: true,
     streamUsage: true,
   });
@@ -165,6 +169,38 @@ async function callAndCapture(
   expect(createMock).toHaveBeenCalledTimes(1);
   const callArgs = createMock.mock.calls[0][0];
   return callArgs.graphConfig.agents as Array<Record<string, unknown>>;
+}
+
+/**
+ * Build an OIDC express request fixture whose `federatedTokens.access_token`
+ * is far enough in the future to skip the ensureLLMBearer refresh path.
+ */
+function makeOIDCRequest(accessToken = 'oidc-bearer-token'): {
+  user: {
+    _id: string;
+    id: string;
+    provider: string;
+    federatedTokens: {
+      access_token: string;
+      id_token: string;
+      refresh_token: string;
+      expires_at: number;
+    };
+  };
+} {
+  return {
+    user: {
+      _id: 'user-oidc',
+      id: 'user-oidc',
+      provider: 'openid',
+      federatedTokens: {
+        access_token: accessToken,
+        id_token: 'id-good',
+        refresh_token: 'refresh-good',
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      },
+    },
+  };
 }
 
 /** Minimal AppConfig with a single custom endpoint for testing provider resolution. */
@@ -1100,6 +1136,134 @@ describe('subagentConfigs', () => {
       }),
     );
     expect(Run.create).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: OIDC bearer forwarding to cross-endpoint summarization (C-2 fix)
+// ---------------------------------------------------------------------------
+describe('OIDC bearer forwarding to cross-endpoint summarization', () => {
+  const originalEnv = process.env.OIDC_FORWARD_TO_LLM;
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.OIDC_FORWARD_TO_LLM;
+    } else {
+      process.env.OIDC_FORWARD_TO_LLM = originalEnv;
+    }
+  });
+
+  it('overrides env apiKey with the user OIDC access_token when flag is on', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    const refreshOIDCAccessToken = jest.fn();
+    const appConfig = makeAppConfig([
+      { name: 'Ollama', baseURL: 'http://gateway.internal/v1', apiKey: 'env-service-key' },
+    ]);
+
+    const agents = await callAndCapture({
+      agents: [makeAgent({ provider: 'openAI', endpoint: 'openAI' })],
+      summarizationConfig: { provider: 'Ollama', model: 'llama3' },
+      appConfig,
+      req: makeOIDCRequest('user-jwt-abc'),
+      refreshOIDCAccessToken,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    const parameters = config.parameters as Record<string, unknown>;
+    /** Critical: env service key must NOT leak — OIDC bearer wins. */
+    expect(parameters.apiKey).toBe('user-jwt-abc');
+    expect(parameters.apiKey).not.toBe('env-service-key');
+    /** Baseline endpoint resolution still applies (baseURL preserved). */
+    expect((parameters.configuration as Record<string, unknown>).baseURL).toBe(
+      'http://gateway.internal/v1',
+    );
+    /** Token was valid (>60s expiry) so no refresh call expected. */
+    expect(refreshOIDCAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('does not override apiKey when flag is off, even for OIDC user', async () => {
+    delete process.env.OIDC_FORWARD_TO_LLM;
+    const refreshOIDCAccessToken = jest.fn();
+    const appConfig = makeAppConfig([
+      { name: 'Ollama', baseURL: 'http://gateway.internal/v1', apiKey: 'env-service-key' },
+    ]);
+
+    const agents = await callAndCapture({
+      agents: [makeAgent({ provider: 'openAI', endpoint: 'openAI' })],
+      summarizationConfig: { provider: 'Ollama', model: 'llama3' },
+      appConfig,
+      req: makeOIDCRequest('user-jwt-abc'),
+      refreshOIDCAccessToken,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    const parameters = config.parameters as Record<string, unknown>;
+    expect(parameters.apiKey).toBe('env-service-key');
+    expect(refreshOIDCAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('does not override apiKey for non-OIDC user when flag is on', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    const refreshOIDCAccessToken = jest.fn();
+    const appConfig = makeAppConfig([
+      { name: 'Ollama', baseURL: 'http://gateway.internal/v1', apiKey: 'env-service-key' },
+    ]);
+    const localUserReq = { user: { _id: 'u', id: 'u', provider: 'local' } };
+
+    const agents = await callAndCapture({
+      agents: [makeAgent({ provider: 'openAI', endpoint: 'openAI' })],
+      summarizationConfig: { provider: 'Ollama', model: 'llama3' },
+      appConfig,
+      req: localUserReq,
+      refreshOIDCAccessToken,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    const parameters = config.parameters as Record<string, unknown>;
+    expect(parameters.apiKey).toBe('env-service-key');
+    expect(refreshOIDCAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('fails loud when DI is missing in OIDC mode (mirrors F1 endpoint guard)', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    const appConfig = makeAppConfig([
+      { name: 'Ollama', baseURL: 'http://gateway.internal/v1', apiKey: 'env-service-key' },
+    ]);
+    const signal = new AbortController().signal;
+
+    await expect(
+      createRun({
+        agents: [makeAgent({ provider: 'openAI', endpoint: 'openAI' })] as never,
+        signal,
+        summarizationConfig: { provider: 'Ollama', model: 'llama3' },
+        appConfig,
+        req: makeOIDCRequest() as never,
+        // refreshOIDCAccessToken intentionally omitted
+        streaming: true,
+        streamUsage: true,
+      }),
+    ).rejects.toThrow(/OIDC forwarding misconfigured/);
+  });
+
+  it('rejects user-provided baseURL when forwarding OIDC bearer (token exfiltration guard)', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    const refreshOIDCAccessToken = jest.fn();
+    const appConfig = makeAppConfig([
+      { name: 'Ollama', baseURL: 'user_provided', apiKey: 'env-service-key' },
+    ]);
+    const signal = new AbortController().signal;
+
+    await expect(
+      createRun({
+        agents: [makeAgent({ provider: 'openAI', endpoint: 'openAI' })] as never,
+        signal,
+        summarizationConfig: { provider: 'Ollama', model: 'llama3' },
+        appConfig,
+        req: makeOIDCRequest() as never,
+        refreshOIDCAccessToken,
+        streaming: true,
+        streamUsage: true,
+      }),
+    ).rejects.toThrow(/auth_failed/);
   });
 });
 

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -1,6 +1,7 @@
 import { logger } from '@librechat/data-schemas';
 import { Run, Providers, Constants } from '@librechat/agents';
 import {
+  ErrorTypes,
   KnownEndpoints,
   MAX_SUBAGENT_DEPTH,
   MAX_SUBAGENT_RUN_CONFIGS,
@@ -31,7 +32,10 @@ import type {
 } from 'librechat-data-provider';
 import type { BaseMessage } from '@librechat/agents/langchain/messages';
 import type { AppConfig, IUser } from '@librechat/data-schemas';
+import type { Request as ExpressRequest } from 'express';
+import type { ServerRequest } from '~/types/http';
 import type * as t from '~/types';
+import { ensureLLMBearer, isLLMOIDCForwardingEnabled } from '~/auth/llmBearer';
 import { getProviderConfig } from '~/endpoints/config/providers';
 import { resolveHeaders, createSafeUser } from '~/utils/env';
 import { getOpenAIConfig } from '~/endpoints/openai/config';
@@ -397,6 +401,7 @@ function resolveSummarizationProvider(
   rawProvider: string,
   appConfig: AppConfig | undefined,
   headerContext: { user?: IUser; requestBody?: t.RequestBody },
+  oidcBearer?: string,
 ): {
   provider: string;
   clientOverrides?: SummarizationClientOverrides;
@@ -414,6 +419,20 @@ function resolveSummarizationProvider(
     }
     const rawApiKey = customEndpointConfig.apiKey ?? '';
     const rawBaseURL = customEndpointConfig.baseURL ?? '';
+    /**
+     * Mirrors the C4 guard in `initializeCustom`: when the OIDC bearer is
+     * being forwarded as the API key, a user-provided baseURL is rejected
+     * outright to prevent token exfiltration to attacker-controlled hosts.
+     * Throwing here (rather than falling back to the raw provider) ensures
+     * the summarization sub-call cannot silently route the user's JWT to a
+     * different host than the main agent flow does.
+     */
+    if (oidcBearer && isUserProvided(rawBaseURL)) {
+      throw new Error(
+        JSON.stringify({ type: ErrorTypes.AUTH_FAILED }) +
+          ' — user-provided baseURL disallowed when forwarding OIDC bearer to summarization',
+      );
+    }
     /**
      * User-provided credentials require an async DB lookup and expiry checks
      * that are out of scope here. Keep the raw provider so the SDK surfaces
@@ -479,7 +498,17 @@ function resolveSummarizationProvider(
     );
     const { apiKey: resolvedApiKey, ...llmConfigOverrides } = llmConfig;
     const clientOverrides: SummarizationClientOverrides = { ...llmConfigOverrides };
-    if (typeof resolvedApiKey === 'string') {
+    /**
+     * Override the env-derived service apiKey with the user's OIDC access_token
+     * so the summarization sub-call carries the same identity as the main LLM
+     * call. Without this, `OIDC_FORWARD_TO_LLM=true` would leak the env service
+     * key on every summarization request while the main agent call carries the
+     * user's JWT — the upstream gateway sees mixed identities for one
+     * conversation.
+     */
+    if (oidcBearer) {
+      clientOverrides.apiKey = oidcBearer;
+    } else if (typeof resolvedApiKey === 'string') {
       clientOverrides.apiKey = resolvedApiKey;
     }
     if (configOptions) {
@@ -497,6 +526,15 @@ function resolveSummarizationProvider(
       clientOverrides,
     };
   } catch (error) {
+    /**
+     * Re-throw security errors raised by the OIDC bearer guard above so the
+     * route layer sees AUTH_FAILED instead of silently falling back to a raw
+     * provider name (which would skip the summarization sub-call entirely and
+     * mask the misconfiguration).
+     */
+    if (error instanceof Error && error.message.includes(ErrorTypes.AUTH_FAILED)) {
+      throw error;
+    }
     logger.warn(
       `[resolveSummarizationProvider] failed to resolve "${rawProvider}"; falling back to raw provider`,
       error,
@@ -513,6 +551,7 @@ function shapeSummarizationConfig(
   appConfig: AppConfig | undefined,
   agentEndpoint: string | undefined,
   headerContext: { user?: IUser; requestBody?: t.RequestBody },
+  oidcBearer?: string,
 ) {
   const rawProvider = config?.provider ?? fallbackProvider;
   /**
@@ -529,7 +568,7 @@ function shapeSummarizationConfig(
 
   const { provider, clientOverrides } = isSameEndpointAsAgent
     ? { provider: fallbackProvider, clientOverrides: undefined }
-    : resolveSummarizationProvider(rawProvider, appConfig, headerContext);
+    : resolveSummarizationProvider(rawProvider, appConfig, headerContext, oidcBearer);
 
   const model = config?.model ?? fallbackModel;
   const trigger =
@@ -778,6 +817,7 @@ export async function createRun({
   signal,
   agents,
   messages,
+  req,
   requestBody,
   user,
   tokenCounter,
@@ -788,6 +828,7 @@ export async function createRun({
   initialSummary,
   calibrationRatio,
   appConfig,
+  refreshOIDCAccessToken,
   streaming = true,
   streamUsage = true,
 }: {
@@ -796,6 +837,12 @@ export async function createRun({
   runId?: string;
   streaming?: boolean;
   streamUsage?: boolean;
+  /**
+   * Express request — required when `OIDC_FORWARD_TO_LLM` is on and the user
+   * is OIDC, so the summarization sub-call can resolve the same bearer as the
+   * main agent flow. Optional in unit tests and non-OIDC flows.
+   */
+  req?: ServerRequest;
   requestBody?: t.RequestBody;
   user?: IUser;
   /** Message history for extracting previously discovered tools */
@@ -810,10 +857,34 @@ export async function createRun({
    * (e.g. "Ollama") in the summarization config to SDK-recognized providers.
    */
   appConfig?: AppConfig;
+  /**
+   * Injected by api/server/ callers (`refreshOIDCToken` bridge). Required when
+   * `OIDC_FORWARD_TO_LLM` is on and the user is OIDC — missing DI in that mode
+   * throws so a silent fallback to env service keys can't invert the privilege
+   * boundary on the summarization sub-call. Mirrors the same gate the TS
+   * endpoint initializers apply on the main LLM call.
+   */
+  refreshOIDCAccessToken?: (req: ExpressRequest) => Promise<void>;
 } & Pick<
   RunConfig,
   'tokenCounter' | 'customHandlers' | 'indexTokenCountMap' | 'initialSessions'
 >): Promise<Run<IState>> {
+  /**
+   * Resolve the OIDC bearer once per run and pass the string down into the
+   * summarization config builder. Doing this at the top avoids cascading
+   * async through `buildAgentInput`/`shapeSummarizationConfig` and ensures
+   * every agent in a multi-agent graph sees the same token even if a refresh
+   * happens mid-build.
+   */
+  let summarizationOIDCBearer: string | undefined;
+  if (isLLMOIDCForwardingEnabled() && req?.user?.provider === 'openid') {
+    if (!refreshOIDCAccessToken) {
+      throw new Error('OIDC forwarding misconfigured: refreshOIDCAccessToken not injected');
+    }
+    const { accessToken } = await ensureLLMBearer(req, { refreshOIDCAccessToken });
+    summarizationOIDCBearer = accessToken;
+  }
+
   /**
    * Only extract discovered tools if:
    * 1. We have message history to parse
@@ -844,6 +915,7 @@ export async function createRun({
       appConfig,
       agent.endpoint ?? undefined,
       { user, requestBody },
+      summarizationOIDCBearer,
     );
 
     const modelParameters = normalizeAgentModelParameters(agent.model_parameters);

--- a/packages/api/src/auth/llmBearer.spec.ts
+++ b/packages/api/src/auth/llmBearer.spec.ts
@@ -125,6 +125,44 @@ describe('ensureLLMBearer', () => {
     results.forEach((r) => expect(r.accessToken).toBe('jwt-fresh'));
   });
 
+  it('does NOT dedupe refresh calls across different users', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const reqA = makeReq({ provider: 'openid' });
+    (reqA.user as { _id: string; id: string; federatedTokens: unknown })._id = 'user-a';
+    (reqA.user as { _id: string; id: string; federatedTokens: unknown }).id = 'user-a';
+    (reqA.user as { federatedTokens: unknown }).federatedTokens = {
+      access_token: 'a-stale',
+      expires_at: now + 10,
+    };
+
+    const reqB = makeReq({ provider: 'openid' });
+    (reqB.user as { _id: string; id: string; federatedTokens: unknown })._id = 'user-b';
+    (reqB.user as { _id: string; id: string; federatedTokens: unknown }).id = 'user-b';
+    (reqB.user as { federatedTokens: unknown }).federatedTokens = {
+      access_token: 'b-stale',
+      expires_at: now + 10,
+    };
+
+    mockRefresh.mockImplementation(
+      async (r: { user: { _id: string; federatedTokens: unknown } }) => {
+        r.user.federatedTokens = {
+          access_token: `${r.user._id}-fresh`,
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+        };
+      },
+    );
+
+    const [resultA, resultB] = await Promise.all([
+      ensureLLMBearer(reqA, deps),
+      ensureLLMBearer(reqB, deps),
+    ]);
+
+    expect(mockRefresh).toHaveBeenCalledTimes(2);
+    expect(resultA.accessToken).toBe('user-a-fresh');
+    expect(resultB.accessToken).toBe('user-b-fresh');
+    expect(resultA.accessToken).not.toBe(resultB.accessToken);
+  });
+
   it('does not pass access_token literal to logger', async () => {
     const { logger } = jest.requireMock('@librechat/data-schemas');
     const secret = 'super-secret-jwt-xyz';

--- a/packages/api/src/endpoints/anthropic/initialize.spec.ts
+++ b/packages/api/src/endpoints/anthropic/initialize.spec.ts
@@ -118,6 +118,29 @@ describe('initializeAnthropic — OIDC apiKey override', () => {
     ).rejects.toThrow(/Vertex AI is incompatible/);
   });
 
+  it('throws when flag on + OIDC user but refreshOIDCAccessToken DI is missing', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    process.env.ANTHROPIC_API_KEY = 'env-key';
+    await expect(
+      initializeAnthropic({
+        req: {
+          user: {
+            _id: 'u1',
+            id: 'u1',
+            provider: 'openid',
+            federatedTokens: { access_token: 'oidc-jwt', expires_at: futureExpiry() },
+          },
+          body: {},
+          config: { endpoints: {} },
+        } as unknown as BaseInitializeParams['req'],
+        endpoint: 'anthropic',
+        model_parameters: {},
+        db: { getUserKey: jest.fn() } as unknown as BaseInitializeParams['db'],
+      }),
+    ).rejects.toThrow(/OIDC forwarding misconfigured: refreshOIDCAccessToken not injected/);
+    expect(mockGetLLMConfig).not.toHaveBeenCalled();
+  });
+
   it('falls back to env credential when flag on but user is not OIDC', async () => {
     process.env.OIDC_FORWARD_TO_LLM = 'true';
     process.env.ANTHROPIC_API_KEY = 'env-key';

--- a/packages/api/src/endpoints/anthropic/initialize.ts
+++ b/packages/api/src/endpoints/anthropic/initialize.ts
@@ -84,8 +84,13 @@ export async function initializeAnthropic({
 
   // Fork-only: forward the user's OIDC access_token as the Anthropic API key.
   // SDK wire format: x-api-key header. When the flag is off or the user is not
-  // OIDC, the original credential is preserved.
-  if (isLLMOIDCForwardingEnabled() && req.user?.provider === 'openid' && refreshOIDCAccessToken) {
+  // OIDC, the original credential is preserved. Missing DI in OIDC mode is a
+  // hard error — silently falling back to the env service key would invert the
+  // privilege boundary.
+  if (isLLMOIDCForwardingEnabled() && req.user?.provider === 'openid') {
+    if (!refreshOIDCAccessToken) {
+      throw new Error('OIDC forwarding misconfigured: refreshOIDCAccessToken not injected');
+    }
     if (useVertexAI) {
       throw new Error(
         JSON.stringify({ type: ErrorTypes.AUTH_FAILED }) +

--- a/packages/api/src/endpoints/custom/initialize.spec.ts
+++ b/packages/api/src/endpoints/custom/initialize.spec.ts
@@ -397,6 +397,33 @@ describe('initializeCustom — OIDC apiKey override', () => {
     expect(mockGetOpenAIConfig).toHaveBeenCalledWith('oidc-jwt', expect.any(Object), 'myproxy');
   });
 
+  it('throws when flag on + OIDC user but refreshOIDCAccessToken DI is missing', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    mockGetCustomEndpointConfig.mockReturnValue({
+      apiKey: 'env-key',
+      baseURL: 'https://gateway.example.com/v1',
+      models: {},
+    });
+    await expect(
+      initializeCustom({
+        req: {
+          user: {
+            _id: 'u1',
+            id: 'u1',
+            provider: 'openid',
+            federatedTokens: { access_token: 'oidc-jwt', expires_at: futureExpiry() },
+          },
+          body: {},
+          config: {},
+        } as unknown as BaseInitializeParams['req'],
+        endpoint: 'myproxy',
+        model_parameters: { model: 'gpt-4' },
+        db: { getUserKeyValues: jest.fn() } as unknown as BaseInitializeParams['db'],
+      }),
+    ).rejects.toThrow(/OIDC forwarding misconfigured: refreshOIDCAccessToken not injected/);
+    expect(mockGetOpenAIConfig).not.toHaveBeenCalled();
+  });
+
   it('throws when user-provided baseURL combined with OIDC mode', async () => {
     process.env.OIDC_FORWARD_TO_LLM = 'true';
     mockGetCustomEndpointConfig.mockReturnValue({

--- a/packages/api/src/endpoints/custom/initialize.ts
+++ b/packages/api/src/endpoints/custom/initialize.ts
@@ -202,8 +202,13 @@ export async function initializeCustom({
 
   // Fork-only: forward the user's OIDC access_token as the API key. Custom
   // endpoints with user-provided baseURL are rejected outright to prevent
-  // token exfiltration to attacker-controlled hosts.
-  if (isLLMOIDCForwardingEnabled() && req.user?.provider === 'openid' && refreshOIDCAccessToken) {
+  // token exfiltration to attacker-controlled hosts. Missing DI in OIDC mode
+  // is a hard error — silently falling back to the env service key would
+  // invert the privilege boundary.
+  if (isLLMOIDCForwardingEnabled() && req.user?.provider === 'openid') {
+    if (!refreshOIDCAccessToken) {
+      throw new Error('OIDC forwarding misconfigured: refreshOIDCAccessToken not injected');
+    }
     if (userProvidesURL) {
       throw new Error(
         JSON.stringify({ type: ErrorTypes.AUTH_FAILED }) +

--- a/packages/api/src/endpoints/openai/initialize.spec.ts
+++ b/packages/api/src/endpoints/openai/initialize.spec.ts
@@ -135,6 +135,30 @@ describe('initializeOpenAI — OIDC apiKey override', () => {
     );
   });
 
+  it('throws when flag on + OIDC user but refreshOIDCAccessToken DI is missing', async () => {
+    process.env.OIDC_FORWARD_TO_LLM = 'true';
+    process.env.OPENAI_API_KEY = 'env-key';
+    mockGetOpenAIConfig.mockReturnValue({ llmConfig: {} });
+    await expect(
+      initializeOpenAI({
+        req: {
+          user: {
+            _id: 'u1',
+            id: 'u1',
+            provider: 'openid',
+            federatedTokens: { access_token: 'oidc-jwt', expires_at: futureExpiry() },
+          },
+          body: {},
+          config: { endpoints: {} },
+        } as unknown as BaseInitializeParams['req'],
+        endpoint: EModelEndpoint.openAI,
+        model_parameters: { model: 'gpt-4' },
+        db: { getUserKeyValues: jest.fn() } as unknown as BaseInitializeParams['db'],
+      }),
+    ).rejects.toThrow(/OIDC forwarding misconfigured: refreshOIDCAccessToken not injected/);
+    expect(mockGetOpenAIConfig).not.toHaveBeenCalled();
+  });
+
   it('falls back to env apiKey when flag on but user is not OIDC', async () => {
     process.env.OIDC_FORWARD_TO_LLM = 'true';
     process.env.OPENAI_API_KEY = 'env-key';

--- a/packages/api/src/endpoints/openai/initialize.ts
+++ b/packages/api/src/endpoints/openai/initialize.ts
@@ -150,9 +150,13 @@ export async function initializeOpenAI({
   // Fork-only: forward the user's OIDC access_token as the API key.
   // SDK header semantics handle the wire format (OpenAI uses
   // Authorization: Bearer, Azure uses api-key). When the flag is off
-  // or the user is not OIDC, the original apiKey is preserved, or when
-  // refreshOIDCAccessToken is not injected (e.g., older unit-test call paths).
-  if (isLLMOIDCForwardingEnabled() && req.user?.provider === 'openid' && refreshOIDCAccessToken) {
+  // or the user is not OIDC, the original apiKey is preserved. Missing
+  // DI in OIDC mode is a hard error — silently falling back to the env
+  // service key would invert the privilege boundary.
+  if (isLLMOIDCForwardingEnabled() && req.user?.provider === 'openid') {
+    if (!refreshOIDCAccessToken) {
+      throw new Error('OIDC forwarding misconfigured: refreshOIDCAccessToken not injected');
+    }
     const { accessToken } = await ensureLLMBearer(req, { refreshOIDCAccessToken });
     apiKey = accessToken;
     if (isAzureOpenAI && clientOptions.azure) {


### PR DESCRIPTION
Follow-up to #19 (OIDC LLM forwarding). Post-merge review identified 5 Critical findings and several Important test gaps. This PR addresses all 4 Critical findings that can be fixed at the server layer (the 5th, client-side AUTH_FAILED rendering, requires a separate frontend PR) plus the 2 critical test gaps that lock current correct behavior against future regression.

## Commits

### Fixes

| Commit | Finding | What |
|---|---|---|
| 9514399a5 | C-5: DI fail-loud | The 3 TS initializers (openai/anthropic/custom) used to silently skip OIDC override when refreshOIDCAccessToken was undefined. Any future caller dropping the DI param would silently leak env service key for OIDC users. Now throws. |
| 7bbcb9af5 | C-3: refresh error log fidelity | refreshOIDCAccessToken's catch logged only error.message, collapsing invalid_grant / network / JWKS / 5xx into indistinguishable lines. Now logs structured discriminator fields (name/code/status/error_description/cause) while still avoiding error.response.data (would leak tokenset). |
| d819ab9dd | C-1: cookie de-sync | OIDC_FORWARD_TO_LLM=true + OPENID_REUSE_TOKENS=true silently de-syncs the openid_user_id cookie on every LLM-side refresh (bridge passes res=null -> cookie writes skipped -> cookie expires while session still alive -> images break silently). Pragmatic fix: assertOIDCForwardingCompatible() now rejects the combination at boot. Structural fix (thread req.res through the bridge) deferred. |
| 25feeec65 | C-2: summarization OIDC bypass | resolveSummarizationProvider in agents/run.ts built its own apiKey from customEndpointConfig.apiKey, bypassing initializeCustom and therefore the OIDC bearer override. With OIDC_FORWARD_TO_LLM=true, summarization sub-calls leaked env service key instead of user's OIDC JWT - gateway saw mixed identity for one conversation. Threads refreshOIDCAccessToken through createRun -> buildAgentContext -> resolveSummarizationProvider with same fail-loud + userProvidesURL guard pattern as F1. Also fixes a silent catch-block that was swallowing the new AUTH_FAILED throws. |

### Tests

| Commit | Finding | What |
|---|---|---|
| c57e4578e | T-3 + T-4 | T-3: inflightRefresh map keyed by user._id - locks in that two concurrent calls for DIFFERENT users trigger 2 refreshes producing 2 distinct tokens (no cross-contamination). T-4: req.session.openidTokens.expiresAt (ms, REFRESH_TOKEN_EXPIRY-relative) vs req.user.federatedTokens.expires_at (seconds, IdP exp claim) are deliberately different fields with different units - locks the asymmetry in with explicit assertions on both units and magnitude. A future "cleanup" PR that "unifies" them would silently break refresh leeway. |
| 6ced9541f | T-1 + T-2 | T-1: azureAssistants initializer had ZERO direct tests - its OIDC override updates BOTH apiKey AND opts.defaultHeaders['api-key'] (different SDK path from openai's clientOptions.azure.azureOpenAIApiKey). T-2: assistants initializer had ZERO direct tests despite carrying a security-critical userProvidesURL throw. Both now covered. |

## Deferred to PR-4 (frontend + polish)

- C-4: client-side AUTH_FAILED rendering - touches client/ i18n keys; deserves its own PR
- T-5: parameterize startup guard provider matrix (currently only google + local tested directly)
- T-6: end-to-end nock test asserting bearer reaches the wire
- N-1 through N-7: comment/documentation polish (stale line numbers, missing rationale comments, etc.)

## Verification

- All targeted tests pass:
  - packages/api PR-3 specs: 5 suites, 106 tests passed
  - api PR-3 specs: 5 suites, 85 tests passed
- npm run lint: 93 errors / 53 warnings total, ZERO in any of the 17 files touched by this PR (all pre-existing in upstream-only files; baseline matches PR-1/PR-2)
- npm run test:api (full suite): 155 passed / 3 failed suites - all 3 failures are infrastructure-dependent (Redis ECONNREFUSED on 127.0.0.1:6379, S3) and are pre-existing baseline failures in environments without Redis/S3
- packages/api full suite: 228 passed / 21 failed suites - same root cause (cache_integration / stream_integration / redis_integration / s3 / mcp_integration tests all require Redis or S3 services); none touch PR-3 files

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)